### PR TITLE
chore: initial Eclipse CSI GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # helm-charts
-This repository contains the helm-charts source from Eclipse Foundation Security Infrastructure projects.
+
+Eclipse CSI helm charts
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.  Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+```bash
+helm repo add eclipse-csi  https://eclipse-csi.github.io/helm-charts
+```
+
+If you had already added this repo earlier, run `helm repo update` to retrieve
+the latest versions of the packages.  You can then run `helm search repo
+in-toto` to see the charts.
+
+## Charts
+
+You can search all eclipse-csi charts using following command:
+
+```bash
+helm search repo eclipse-csi
+```

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+entries:
+   ghproxy:
+   otterdog:


### PR DESCRIPTION
- This pages uses index.yaml that will be automatically updated by the CI/CD during the helm releases

- The README.md follows the standard page used by helm charts repo