### PR TITLE
PIA: run migrations via a pre-upgrade hook + bring-your-own secrets

### DIFF
--- a/charts/pia/Chart.yaml
+++ b/charts/pia/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pia
 description: A Helm chart for PIA (Project Identity Authority)
 type: application
-version: 0.1.0
-appVersion: "0.2.1"
+version: 0.2.0
+appVersion: "0.5.0"
 keywords:
   - pia
   - dependency-track

--- a/charts/pia/templates/NOTES.txt
+++ b/charts/pia/templates/NOTES.txt
@@ -25,12 +25,21 @@
    Set the API key using:
      --set config.dependencyTrackApiKey=YOUR_API_KEY
    {{- end }}
-   {{- if and (not .Values.config.databaseUrl) (not .Values.config.existingSecret) }}
-   WARNING: No PostgreSQL database configured!
-   PIA requires a reachable PostgreSQL database and runs schema migrations on
-   startup. Set the connection string using:
-     --set config.databaseUrl=postgresql://user:pass@host:5432/pia
-   or reference an existing secret with config.existingSecret.
+   {{- if and (not .Values.config.databaseUrl) (not .Values.config.dbExistingSecret) }}
+   WARNING: No runtime PostgreSQL database configured!
+   PIA requires a reachable PostgreSQL database. The app reads from it using a
+   read-only user. Set the connection string using:
+     --set config.databaseUrl=postgresql://pia_app:pass@host:5432/pia
+   or reference an existing secret with config.dbExistingSecret.
+   {{- end }}
+   {{- if and .Values.migration.enabled (not .Values.migration.databaseUrl) (not .Values.migration.dbExistingSecret) }}
+   WARNING: Migrations are enabled but no migration database URL is configured!
+   Schema migrations run as a pre-install/pre-upgrade hook job under a user with
+   DDL privileges. Set it using:
+     --set migration.databaseUrl=postgresql://pia_migrate:pass@host:5432/pia
+   or reference an existing secret with migration.dbExistingSecret.
+   (Disable the hook with --set migration.enabled=false if migrations are run
+   out of band.)
    {{- end }}
 
    Dependency Track URL: {{ .Values.config.dependencyTrackUrl }}

--- a/charts/pia/templates/NOTES.txt
+++ b/charts/pia/templates/NOTES.txt
@@ -20,10 +20,11 @@
 {{- end }}
 
 2. Configuration:
-   {{- if not .Values.config.dependencyTrackApiKey }}
+   {{- if and (not .Values.config.dependencyTrackApiKey) (not .Values.config.dtApiExistingSecret) }}
    WARNING: No Dependency Track API key configured!
    Set the API key using:
      --set config.dependencyTrackApiKey=YOUR_API_KEY
+   or reference an existing secret with config.dtApiExistingSecret.
    {{- end }}
    {{- if and (not .Values.config.databaseUrl) (not .Values.config.dbExistingSecret) }}
    WARNING: No runtime PostgreSQL database configured!

--- a/charts/pia/templates/deployment.yaml
+++ b/charts/pia/templates/deployment.yaml
@@ -59,7 +59,13 @@ spec:
                   name: {{ include "pia.fullname" . }}-secret
                   key: PIA_DATABASE_URL
             {{- end }}
-            {{- if .Values.config.dependencyTrackApiKey }}
+            {{- if .Values.config.dtApiExistingSecret }}
+            - name: PIA_DEPENDENCY_TRACK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.dtApiExistingSecret }}
+                  key: {{ .Values.config.dtApiExistingSecretKey | default "PIA_DEPENDENCY_TRACK_API_KEY" }}
+            {{- else if .Values.config.dependencyTrackApiKey }}
             - name: PIA_DEPENDENCY_TRACK_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/pia/templates/deployment.yaml
+++ b/charts/pia/templates/deployment.yaml
@@ -46,12 +46,12 @@ spec:
               value: {{ .Values.config.dependencyTrackUrl | quote }}
             - name: PIA_EXPECTED_AUDIENCE
               value: {{ .Values.config.expectedAudience | quote }}
-            {{- if .Values.config.existingSecret }}
+            {{- if .Values.config.dbExistingSecret }}
             - name: PIA_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.existingSecret }}
-                  key: {{ .Values.config.existingSecretKey | default "PIA_DATABASE_URL" }}
+                  name: {{ .Values.config.dbExistingSecret }}
+                  key: {{ .Values.config.dbExistingSecretKey | default "PIA_DATABASE_URL" }}
             {{- else if .Values.config.databaseUrl }}
             - name: PIA_DATABASE_URL
               valueFrom:

--- a/charts/pia/templates/migration-job.yaml
+++ b/charts/pia/templates/migration-job.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Include the release revision: a Job spec is immutable, so a fixed name would
+  # make the next "helm upgrade" fail. before-hook-creation cleans up the prior.
+  name: {{ include "pia.fullname" . }}-migrate-{{ .Release.Revision }}
+  labels:
+    {{- include "pia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    # Keep a failed job so its logs can be inspected; remove on success.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migration.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migration.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "pia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+      {{- with .Values.migration.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pia.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Override the image's default command (uvicorn) to run migrations.
+          command: ["alembic", "upgrade", "head"]
+          env:
+            {{- if .Values.migration.dbExistingSecret }}
+            - name: PIA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migration.dbExistingSecret }}
+                  key: {{ .Values.migration.dbExistingSecretKey | default "PIA_DATABASE_URL" }}
+            {{- else }}
+            - name: PIA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pia.fullname" . }}-migrate-secret
+                  key: PIA_DATABASE_URL
+            {{- end }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+{{- end }}

--- a/charts/pia/templates/migration-secret.yaml
+++ b/charts/pia/templates/migration-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.migration.enabled .Values.migration.databaseUrl (not .Values.migration.dbExistingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pia.fullname" . }}-migrate-secret
+  labels:
+    {{- include "pia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    # Created as a hook with a lower weight than the migration job so it exists
+    # before the job runs (non-hook resources are only applied after pre-* hooks).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+type: Opaque
+stringData:
+  PIA_DATABASE_URL: {{ .Values.migration.databaseUrl | quote }}
+{{- end }}

--- a/charts/pia/templates/secret.yaml
+++ b/charts/pia/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.config.dependencyTrackApiKey (and .Values.config.databaseUrl (not .Values.config.dbExistingSecret)) }}
+{{- if or (and .Values.config.dependencyTrackApiKey (not .Values.config.dtApiExistingSecret)) (and .Values.config.databaseUrl (not .Values.config.dbExistingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "pia.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- if .Values.config.dependencyTrackApiKey }}
+  {{- if and .Values.config.dependencyTrackApiKey (not .Values.config.dtApiExistingSecret) }}
   PIA_DEPENDENCY_TRACK_API_KEY: {{ .Values.config.dependencyTrackApiKey | quote }}
   {{- end }}
   {{- if and .Values.config.databaseUrl (not .Values.config.dbExistingSecret) }}

--- a/charts/pia/templates/secret.yaml
+++ b/charts/pia/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.config.dependencyTrackApiKey (and .Values.config.databaseUrl (not .Values.config.existingSecret)) }}
+{{- if or .Values.config.dependencyTrackApiKey (and .Values.config.databaseUrl (not .Values.config.dbExistingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +10,7 @@ stringData:
   {{- if .Values.config.dependencyTrackApiKey }}
   PIA_DEPENDENCY_TRACK_API_KEY: {{ .Values.config.dependencyTrackApiKey | quote }}
   {{- end }}
-  {{- if and .Values.config.databaseUrl (not .Values.config.existingSecret) }}
+  {{- if and .Values.config.databaseUrl (not .Values.config.dbExistingSecret) }}
   PIA_DATABASE_URL: {{ .Values.config.databaseUrl | quote }}
   {{- end }}
 {{- end }}

--- a/charts/pia/values.yaml
+++ b/charts/pia/values.yaml
@@ -23,6 +23,13 @@ config:
   # This should be set via --set or values override for security
   dependencyTrackApiKey: ""
 
+  # Reference an existing secret that already holds the Dependency Track API key
+  # instead of storing it in this chart's secret. When set, dependencyTrackApiKey
+  # above is ignored.
+  dtApiExistingSecret: ""
+  # Key within dtApiExistingSecret that holds the API key.
+  dtApiExistingSecretKey: "PIA_DEPENDENCY_TRACK_API_KEY"
+
   # PostgreSQL connection string for the RUNTIME app (required).
   # This is used by the long-lived app pods, which only read from the database,
   # so this user only needs CONNECT + USAGE + SELECT. Schema changes are applied

--- a/charts/pia/values.yaml
+++ b/charts/pia/values.yaml
@@ -5,8 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/eclipse-csi/pia
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.1"
+  tag: "0.5.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -24,19 +23,47 @@ config:
   # This should be set via --set or values override for security
   dependencyTrackApiKey: ""
 
-  # PostgreSQL connection string (required as of PIA 0.3.0)
-  # PIA runs Alembic migrations against this database on startup, so it must
-  # point to a reachable PostgreSQL instance (no dummy value).
-  # Example: postgresql://pia:password@postgres.example.com:5432/pia
+  # PostgreSQL connection string for the RUNTIME app (required).
+  # This is used by the long-lived app pods, which only read from the database,
+  # so this user only needs CONNECT + USAGE + SELECT. Schema changes are applied
+  # by the migration job below under a separate, higher-privileged user.
+  # Example: postgresql://pia_app:password@postgres.example.com:5432/pia
   # For security, set this via --set or a values override, or reference an
   # existing secret below instead.
   databaseUrl: ""
 
   # Reference an existing secret that already holds the database URL instead of
   # storing it in this chart's secret. When set, databaseUrl above is ignored.
-  existingSecret: ""
-  # Key within existingSecret that holds the PostgreSQL connection string.
-  existingSecretKey: "PIA_DATABASE_URL"
+  dbExistingSecret: ""
+  # Key within dbExistingSecret that holds the PostgreSQL connection string.
+  dbExistingSecretKey: "PIA_DATABASE_URL"
+
+## Database migration job
+# Runs "alembic upgrade head" as a Helm pre-install/pre-upgrade hook, before the
+# app Deployment is rolled out. This gates the rollout on a successful migration
+# and keeps schema-changing (DDL) privileges out of the long-lived app pods.
+migration:
+  enabled: true
+
+  # PostgreSQL connection string for the MIGRATION user. This user needs DDL
+  # privileges (CREATE/ALTER/DROP) on the schema; the simplest setup is for it
+  # to own the database. Keep this separate from config.databaseUrl above.
+  # Example: postgresql://pia_migrate:password@postgres.example.com:5432/pia
+  databaseUrl: ""
+
+  # Alternatively, reference an existing secret holding the migration URL
+  # (recommended for the high-privilege credential — provision it out of band).
+  # When set, migration.databaseUrl above is ignored.
+  dbExistingSecret: ""
+  dbExistingSecretKey: "PIA_DATABASE_URL"
+
+  # Job tuning. backoffLimit caps retries; activeDeadlineSeconds fails the
+  # release (instead of blocking forever) if a migration hangs.
+  backoffLimit: 1
+  activeDeadlineSeconds: 600
+
+  podAnnotations: {}
+  resources: {}
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Reworks how the pia chart handles database migrations and credentials:

 1. Migrations run as a Helm pre-install/pre-upgrade hook Job (alembic upgrade head) — gating the rollout on a successful migration and keeping schema-changing (DDL) privileges out of the long-lived app pods.

2. Every credential can be supplied via an existing secret — the Dependency Track API key, the app's runtime DB URL, and the migration DB URL — so plaintext never has to pass through Helm values/release history.

Chart bumped to 0.2.0; appVersion 0.5.0 (requires a PIA with db integration and whose default command is plain uvicorn, i.e. it does not migrate on startup).