### PR TITLE
ghproxy Vault secrets operator integration

### DIFF
--- a/charts/ghproxy/Chart.yaml
+++ b/charts/ghproxy/Chart.yaml
@@ -13,5 +13,5 @@ description: A Helm chart for ghproxy
 maintainers:
   - name: eclipse-csi
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "v20251030-0e4d5be42"

--- a/charts/ghproxy/README.md
+++ b/charts/ghproxy/README.md
@@ -1,0 +1,144 @@
+# ghproxy
+
+![Version: 0.3.0][version-badge] <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: v20251030-0e4d5be42](https://img.shields.io/badge/AppVersion-v20251030--0e4d5be42-informational?style=flat-square)
+
+A Helm chart for ghproxy
+
+## Installation
+
+`ghproxy` is a [caching reverse proxy for the GitHub API](https://github.com/kubernetes/test-infra/tree/master/ghproxy),
+backed by Redis/Valkey. It is deployed as a stand-alone chart, or as a sub-chart
+dependency of the `otterdog` chart.
+
+Add the Eclipse CSI Helm repository:
+
+```console
+helm repo add eclipse-csi https://eclipse-csi.github.io/helm-charts
+helm repo update
+```
+
+Install the chart with the release name `ghproxy`:
+
+```console
+helm install ghproxy eclipse-csi/ghproxy \
+  --namespace ghproxy --create-namespace
+```
+
+Provide your own configuration with a values file:
+
+```console
+helm install ghproxy eclipse-csi/ghproxy \
+  --namespace ghproxy --create-namespace \
+  -f my-values.yaml
+```
+
+Or override individual values on the command line:
+
+```console
+helm install ghproxy eclipse-csi/ghproxy \
+  --namespace ghproxy --create-namespace \
+  --set redisAddress=my-redis:6379 \
+  --set throttlingTimeMs=50
+```
+
+Upgrade an existing release:
+
+```console
+helm upgrade ghproxy eclipse-csi/ghproxy \
+  --namespace ghproxy -f my-values.yaml
+```
+
+Uninstall the release:
+
+```console
+helm uninstall ghproxy --namespace ghproxy
+```
+
+> **Note:** ghproxy needs a Redis/Valkey instance to cache against. If none is deployed
+> alongside it (e.g. when installed standalone, without the otterdog parent chart's
+> `valkey` sub-chart), set `redisAddress` explicitly. See the [Secrets](#secrets) section
+> below for how the Redis password is supplied, and the [Values](#values) section for all
+> other options.
+
+## Secrets
+
+The only secret this chart manages is the Redis/Valkey password, supplied in one of two
+mutually exclusive ways, controlled by `vault.enabled`.
+
+### Non-Vault mode (`vault.enabled: false`)
+
+`redisPassword` is read from `values.yaml` and rendered into a `<release>-redis-auth`
+Kubernetes `Secret` by `templates/secret.yaml`. This is intended for local/dev use only —
+do not commit real secrets. Leave `redisPassword` empty to run against an unauthenticated
+Redis/Valkey instance (no secret/volume is mounted in that case).
+
+### Vault mode (`vault.enabled: true`)
+
+The password is synced from HashiCorp Vault by the
+[Vault Secrets Operator (VSO)](https://developer.hashicorp.com/vault/docs/platform/k8s/vso).
+`templates/vault-static-secret.yaml` creates a `VaultAuth` and a `VaultStaticSecret` that
+syncs into the `<release>-redis-auth` Kubernetes `Secret`.
+
+The key is read from a single Vault KV v2 entry:
+
+```
+<vault.secretMount>/data/<vault.secretPath>     e.g. csi/data/otterdog/dev
+```
+
+| Vault key | Kubernetes Secret (VSO destination) | Consumed as |
+| --------- | ----------------------------------- | ----------- |
+| `valkey_password` | `<release>-redis-auth` (key `redis-password`) | file `/etc/ghproxy-redis/redis-password` (arg `--redis-secret-file`) |
+
+Notes:
+
+- `vault.serviceAccountName` (default `secrets-manager-sa`) is the Kubernetes
+  **ServiceAccount used to authenticate the `VaultAuth` login**.
+- Vault connection settings (`vault.authPath`, `vault.role`, `vault.secretMount`,
+  `vault.secretPath`) must match a Kubernetes auth role in Vault that authorizes
+  `vault.serviceAccountName` in this release's namespace.
+- `redisUsername` defaults to `"default"` whenever a password is in use (`redisPassword`
+  set or `vault.enabled: true`) and no explicit username is given — matching Redis/Valkey's
+  own default ACL user name.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.repository | string | `"us-docker.pkg.dev/k8s-infra-prow/images/ghproxy"` |  |
+| image.tag | string | `"v20251030-0e4d5be42"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| redisAddress | string | `""` |  |
+| redisUsername | string | `""` |  |
+| redisPassword | string | `"changeme"` |  |
+| legacyDisableDiskCachePartitionsByAuthHeader | bool | `false` |  |
+| throttlingTimeMs | int | `10` |  |
+| getThrottlingTimeMs | int | `10` |  |
+| logLevel | string | `"info"` |  |
+| extraArgs | list | `[]` |  |
+| service.port | int | `8888` |  |
+| persistence.enabled | bool | `true` |  |
+| persistence.mountPath | string | `"/cache/"` |  |
+| persistence.size | string | `"1Gi"` |  |
+| persistence.storageClassName | string | `""` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.name | string | `""` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| vault.enabled | bool | `false` | Enable Vault Secrets Operator (VSO) integration for the redis-password secret |
+| vault.authPath | string | `""` | Vault Kubernetes auth path, e.g. auth/kubernetes-<instance>-<env>-<namespace> |
+| vault.role | string | `""` | Vault role for authentication, e.g. <instance>-<env>_<namespace>_role |
+| vault.secretMount | string | `"csi"` | Vault KV v2 secrets engine mount path, e.g. csi |
+| vault.secretPath | string | `"otterdog/dev"` | Full path inside the mount, e.g. otterdog/<env> → csi/data/otterdog/staging |
+| vault.serviceAccountName | string | `"secrets-manager-sa"` | Service account name for the Vault Kubernetes auth method (optional; defaults to "secrets-manager-sa") |
+| vault.operator | object | `{"refreshAfter":"30s"}` | VSO operator configuration |
+| vault.operator.refreshAfter | string | `"30s"` | How often VSO syncs the secret from Vault (e.g. 30s, 1m) |
+
+<!-- x-release-please-start-version -->
+[version-badge]: https://img.shields.io/badge/Version-0.3.0%2Dinformational?style=flat-square
+<!-- x-release-please-end -->

--- a/charts/ghproxy/README.md.gotmpl
+++ b/charts/ghproxy/README.md.gotmpl
@@ -1,0 +1,116 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+![Version: {{ template "chart.version" . }}][version-badge] <!-- x-release-please-version -->
+{{ template "chart.typeBadge" . }}
+{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installation
+
+`ghproxy` is a [caching reverse proxy for the GitHub API](https://github.com/kubernetes/test-infra/tree/master/ghproxy),
+backed by Redis/Valkey. It is deployed as a stand-alone chart, or as a sub-chart
+dependency of the `otterdog` chart.
+
+Add the Eclipse CSI Helm repository:
+
+```console
+helm repo add eclipse-csi https://eclipse-csi.github.io/helm-charts
+helm repo update
+```
+
+Install the chart with the release name `ghproxy`:
+
+```console
+helm install ghproxy eclipse-csi/{{ template "chart.name" . }} \
+  --namespace ghproxy --create-namespace
+```
+
+Provide your own configuration with a values file:
+
+```console
+helm install ghproxy eclipse-csi/{{ template "chart.name" . }} \
+  --namespace ghproxy --create-namespace \
+  -f my-values.yaml
+```
+
+Or override individual values on the command line:
+
+```console
+helm install ghproxy eclipse-csi/{{ template "chart.name" . }} \
+  --namespace ghproxy --create-namespace \
+  --set redisAddress=my-redis:6379 \
+  --set throttlingTimeMs=50
+```
+
+Upgrade an existing release:
+
+```console
+helm upgrade ghproxy eclipse-csi/{{ template "chart.name" . }} \
+  --namespace ghproxy -f my-values.yaml
+```
+
+Uninstall the release:
+
+```console
+helm uninstall ghproxy --namespace ghproxy
+```
+
+> **Note:** ghproxy needs a Redis/Valkey instance to cache against. If none is deployed
+> alongside it (e.g. when installed standalone, without the otterdog parent chart's
+> `valkey` sub-chart), set `redisAddress` explicitly. See the [Secrets](#secrets) section
+> below for how the Redis password is supplied, and the [Values](#values) section for all
+> other options.
+
+## Secrets
+
+The only secret this chart manages is the Redis/Valkey password, supplied in one of two
+mutually exclusive ways, controlled by `vault.enabled`.
+
+### Non-Vault mode (`vault.enabled: false`)
+
+`redisPassword` is read from `values.yaml` and rendered into a `<release>-redis-auth`
+Kubernetes `Secret` by `templates/secret.yaml`. This is intended for local/dev use only —
+do not commit real secrets. Leave `redisPassword` empty to run against an unauthenticated
+Redis/Valkey instance (no secret/volume is mounted in that case).
+
+### Vault mode (`vault.enabled: true`)
+
+The password is synced from HashiCorp Vault by the
+[Vault Secrets Operator (VSO)](https://developer.hashicorp.com/vault/docs/platform/k8s/vso).
+`templates/vault-static-secret.yaml` creates a `VaultAuth` and a `VaultStaticSecret` that
+syncs into the `<release>-redis-auth` Kubernetes `Secret`.
+
+The key is read from a single Vault KV v2 entry:
+
+```
+<vault.secretMount>/data/<vault.secretPath>     e.g. csi/data/otterdog/dev
+```
+
+| Vault key | Kubernetes Secret (VSO destination) | Consumed as |
+| --------- | ----------------------------------- | ----------- |
+| `valkey_password` | `<release>-redis-auth` (key `redis-password`) | file `/etc/ghproxy-redis/redis-password` (arg `--redis-secret-file`) |
+
+Notes:
+
+- `vault.serviceAccountName` (default `secrets-manager-sa`) is the Kubernetes
+  **ServiceAccount used to authenticate the `VaultAuth` login**.
+- Vault connection settings (`vault.authPath`, `vault.role`, `vault.secretMount`,
+  `vault.secretPath`) must match a Kubernetes auth role in Vault that authorizes
+  `vault.serviceAccountName` in this release's namespace.
+- `redisUsername` defaults to `"default"` whenever a password is in use (`redisPassword`
+  set or `vault.enabled: true`) and no explicit username is given — matching Redis/Valkey's
+  own default ACL user name.
+
+{{ template "chart.valuesSection" . }}
+
+<!-- x-release-please-start-version -->
+[version-badge]: https://img.shields.io/badge/Version-{{ template "chart.version" . }}%2Dinformational?style=flat-square
+<!-- x-release-please-end -->

--- a/charts/ghproxy/templates/_helpers.tpl
+++ b/charts/ghproxy/templates/_helpers.tpl
@@ -72,10 +72,29 @@ Create the name of the service account to use
 
 
 {{/*
+Redis/Valkey address.
+Auto-derived from the valkey service (<release>-valkey.<namespace>) when not set.
+Override with .Values.redisAddress.
+*/}}
+{{- define "ghproxy.redisAddress" -}}
+{{- .Values.redisAddress | default (printf "%s-valkey.%s.svc.cluster.local:6379" .Release.Name .Release.Namespace) -}}
+{{- end -}}
+
+{{/*
+Redis/Valkey username.
+Falls back to "default" when a password is in use (redisPassword set or vault.enabled)
+and no explicit username is provided; otherwise empty (no --redis-username).
+*/}}
+{{- define "ghproxy.redisUsername" -}}
+{{- $withPassword := or .Values.redisPassword .Values.vault.enabled -}}
+{{- .Values.redisUsername | default (ternary "default" "" (not (empty $withPassword))) -}}
+{{- end -}}
+
+{{/*
 Extract Redis host from URI
 */}}
 {{- define "ghproxy.redis.host" -}}
-{{- $uri := .Values.redisAddress | default "" -}}
+{{- $uri := include "ghproxy.redisAddress" . -}}
 {{- /* Try extracting host after @ if auth is present */ -}}
 {{- $host := regexFind "@([^:/]+)" $uri | trimPrefix "@" -}}
 {{- /* If no auth, get the host directly after scheme or start of string */ -}}
@@ -90,7 +109,7 @@ Extract Redis host from URI
 Extract Redis port from URI
 */}}
 {{- define "ghproxy.redis.port" -}}
-{{- $uri := .Values.redisAddress | default "" -}}
+{{- $uri := include "ghproxy.redisAddress" . -}}
 {{- $port := regexFind ":([0-9]+)$" $uri | trimPrefix ":" -}}
 {{- default "6379" $port -}}
 {{- end -}}

--- a/charts/ghproxy/templates/deployment.yaml
+++ b/charts/ghproxy/templates/deployment.yaml
@@ -37,13 +37,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-          {{- if .Values.redisAddress }}
-            - "--redis-address={{ .Values.redisAddress }}"
+            - "--redis-address={{ include "ghproxy.redisAddress" . }}"
+          {{- $redisUsername := include "ghproxy.redisUsername" . }}
+          {{- if $redisUsername }}
+            - "--redis-username={{ $redisUsername }}"
           {{- end }}
-          {{- if .Values.redisUsername }}
-            - "--redis-username={{ .Values.redisUsername }}"
-          {{- end }}
-          {{- if .Values.redisPassword }}
+          {{- if or .Values.redisPassword .Values.vault.enabled }}
             - "--redis-secret-file=/etc/ghproxy-redis/redis-password"
           {{- end }}
           {{- if ne .Values.legacyDisableDiskCachePartitionsByAuthHeader nil }}
@@ -68,7 +67,7 @@ spec:
           volumeMounts:
             - name: cache-volume
               mountPath: {{ .Values.persistence.mountPath }}
-            {{- if .Values.redisPassword }}
+            {{- if or .Values.redisPassword .Values.vault.enabled }}
             - name: redis-secret
               mountPath: /etc/ghproxy-redis
               readOnly: true
@@ -82,7 +81,7 @@ spec:
           hostPath:
             path: ../approot/ghcache
           {{- end }}
-        {{- if .Values.redisPassword }}
+        {{- if or .Values.redisPassword .Values.vault.enabled }}
         - name: redis-secret
           secret:
             secretName: {{ include "ghproxy.fullname" . }}-redis-auth

--- a/charts/ghproxy/templates/secret.yaml
+++ b/charts/ghproxy/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if or .Values.redisUsername .Values.redisPassword }}
+{{- if not .Values.vault.enabled }}
+{{- if .Values.redisPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,10 +8,8 @@ metadata:
     {{- include "ghproxy.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.redisUsername }}
-  redis-username: {{ .Values.redisUsername | b64enc | quote }}
-  {{- end }}
   {{- if .Values.redisPassword }}
   redis-password: {{ .Values.redisPassword | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/ghproxy/templates/vault-static-secret.yaml
+++ b/charts/ghproxy/templates/vault-static-secret.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.vault.enabled }}
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: {{ include "ghproxy.fullname" . }}-vault-auth
+  labels:
+    {{- include "ghproxy.labels" . | nindent 4 }}
+spec:
+  method: kubernetes
+  {{- /*
+    authPath is "auth/kubernetes-..." — VSO expects the mount without the leading "auth/" prefix.
+  */}}
+  mount: {{ trimPrefix "auth/" .Values.vault.authPath }}
+  kubernetes:
+    role: {{ .Values.vault.role }}
+    serviceAccount: {{ .Values.vault.serviceAccountName | default "secrets-manager-sa"}}
+---
+{{- /*
+  VaultStaticSecret: valkey_password (Vault) → redis-password key of the
+  {{ include "ghproxy.fullname" . }}-redis-auth Secret.
+  Consumed by the deployment through --redis-secret-file=/etc/ghproxy-redis/redis-password.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "ghproxy.fullname" . }}-redis-auth-vss
+  labels:
+    {{- include "ghproxy.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "ghproxy.fullname" . }}-redis-auth
+    create: true
+    transformation:
+      templates:
+        redis-password:
+          text: '{{ `{{- .Secrets.valkey_password -}}` }}'
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "ghproxy.fullname" . }}-vault-auth
+{{- end }}

--- a/charts/ghproxy/values.yaml
+++ b/charts/ghproxy/values.yaml
@@ -12,13 +12,15 @@ image:
   tag: v20251030-0e4d5be42
   pullPolicy: IfNotPresent
 
-redisAddress: valkey:6379
+# Redis/Valkey address. Leave empty to auto-derive the valkey service
+# (<release>-valkey.<namespace>.svc.cluster.local:6379).
+redisAddress: ""
 redisUsername: ""
-redisPassword: ""
+redisPassword: "changeme"
 legacyDisableDiskCachePartitionsByAuthHeader: false
 throttlingTimeMs: 10
 getThrottlingTimeMs: 10
-logLevel: error
+logLevel: info
 # Additional custom arguments (if needed)
 # Example:
 # extraArgs:
@@ -51,3 +53,25 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+# When vault.enabled is true, the redis-password is synced from Vault via the
+# Vault Secrets Operator (VSO) into the <release>-ghproxy-redis-auth Secret.
+# Vault key mapping:
+#   valkey_password → <release>-ghproxy-redis-auth (key: redis-password)
+vault:
+  # -- Enable Vault Secrets Operator (VSO) integration for the redis-password secret
+  enabled: false
+  # -- Vault Kubernetes auth path, e.g. auth/kubernetes-<instance>-<env>-<namespace>
+  authPath: ""
+  # -- Vault role for authentication, e.g. <instance>-<env>_<namespace>_role
+  role: ""
+  # -- Vault KV v2 secrets engine mount path, e.g. csi
+  secretMount: "csi"
+  # -- Full path inside the mount, e.g. otterdog/<env> → csi/data/otterdog/staging
+  secretPath: "otterdog/dev"
+    # -- Service account name for the Vault Kubernetes auth method (optional; defaults to "secrets-manager-sa")
+  serviceAccountName: "secrets-manager-sa"
+    # -- VSO operator configuration
+  operator:
+    # -- How often VSO syncs the secret from Vault (e.g. 30s, 1m)
+    refreshAfter: "30s"


### PR DESCRIPTION
## Vault Secrets Operator integration

### Vault mode (`vault.enabled: true`)

The password is synced from HashiCorp Vault by the
[Vault Secrets Operator (VSO)](https://developer.hashicorp.com/vault/docs/platform/k8s/vso).
`templates/vault-static-secret.yaml` creates a `VaultAuth` and a `VaultStaticSecret` that
syncs into the `<release>-redis-auth` Kubernetes `Secret`.

The key is read from a single Vault KV v2 entry:

```
<vault.secretMount>/data/<vault.secretPath>     e.g. csi/data/otterdog/dev
```

| Vault key | Kubernetes Secret (VSO destination) | Consumed as |
| --------- | ----------------------------------- | ----------- |
| `valkey_password` | `<release>-redis-auth` (key `redis-password`) | file `/etc/ghproxy-redis/redis-password` (arg `--redis-secret-file`) |

Notes:

- `vault.serviceAccountName` (default `secrets-manager-sa`) is the Kubernetes
  **ServiceAccount used to authenticate the `VaultAuth` login**.
- Vault connection settings (`vault.authPath`, `vault.role`, `vault.secretMount`,
  `vault.secretPath`) must match a Kubernetes auth role in Vault that authorizes
  `vault.serviceAccountName` in this release's namespace.
- `redisUsername` defaults to `"default"` whenever a password is in use (`redisPassword`
  set or `vault.enabled: true`) and no explicit username is given — matching Redis/Valkey's
  own default ACL user name.