### PR TITLE
Otterdog vault secrets operator integration

### DIFF
--- a/charts/otterdog/Chart.yaml
+++ b/charts/otterdog/Chart.yaml
@@ -10,13 +10,35 @@
 apiVersion: v2
 name: otterdog
 description: An otterdog Web App Helm chart for Kubernetes
+home: https://github.com/eclipse-csi/otterdog
+icon: https://raw.githubusercontent.com/eclipse-csi/.github/refs/heads/main/artwork/eclipse-otterdog/Logo%20Color%20-%20Transparent%20Bg.png
+sources:
+  - https://github.com/eclipse-csi/otterdog
+  - https://github.com/eclipse-csi/helm-charts
+keywords:
+  - otterdog
+  - github
+  - configuration-as-code
+  - eclipse
+  - security
 maintainers:
-  - name: eclipse-csi
+- name:  Eclipse Common Security Infrastructure
+  url: https://github.com/eclipse-csi/otterdog/
 type: application
+kubeVersion: ">=1.23.0-0"
 version: 1.1.12
 appVersion: "1.3.4"
 dependencies:
   - name: ghproxy
-    version: 0.3.0
+    version: 0.4.0
+    # repository: "file://../ghproxy"
     repository: "https://eclipse-csi.github.io/helm-charts"
     condition: ghproxy.enabled
+  - name: mongodb
+    version: 0.18.1
+    repository: "oci://registry-1.docker.io/cloudpirates"
+    condition: mongodb.enabled
+  - name: valkey
+    version: 0.24.3
+    repository: "oci://registry-1.docker.io/cloudpirates"
+    condition: valkey.enabled

--- a/charts/otterdog/Chart.yaml
+++ b/charts/otterdog/Chart.yaml
@@ -27,7 +27,7 @@ maintainers:
 type: application
 kubeVersion: ">=1.23.0-0"
 version: 1.1.12
-appVersion: "1.3.4"
+appVersion: "1.4.0"
 dependencies:
   - name: ghproxy
     version: 0.4.0

--- a/charts/otterdog/Chart.yaml
+++ b/charts/otterdog/Chart.yaml
@@ -26,7 +26,7 @@ maintainers:
   url: https://github.com/eclipse-csi/otterdog/
 type: application
 kubeVersion: ">=1.23.0-0"
-version: 1.1.12
+version: 1.2.0
 appVersion: "1.4.0"
 dependencies:
   - name: ghproxy

--- a/charts/otterdog/Chart.yaml
+++ b/charts/otterdog/Chart.yaml
@@ -22,8 +22,8 @@ keywords:
   - eclipse
   - security
 maintainers:
-- name:  Eclipse Common Security Infrastructure
-  url: https://github.com/eclipse-csi/otterdog/
+  - name: eclipse-csi
+    url: https://github.com/eclipse-csi/otterdog/
 type: application
 kubeVersion: ">=1.23.0-0"
 version: 1.2.0

--- a/charts/otterdog/README.md
+++ b/charts/otterdog/README.md
@@ -1,0 +1,333 @@
+# otterdog
+
+![Version: 1.1.12][version-badge] <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: 1.3.4](https://img.shields.io/badge/AppVersion-1.3.4-informational?style=flat-square)
+
+An otterdog Web App Helm chart for Kubernetes
+
+**Homepage:** <https://github.com/eclipse-csi/otterdog>
+
+## Source Code
+
+* <https://github.com/eclipse-csi/otterdog>
+* <https://github.com/eclipse-csi/helm-charts>
+
+## Requirements
+
+Kubernetes: `>=1.23.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://eclipse-csi.github.io/helm-charts | ghproxy | 0.4.0 |
+| oci://registry-1.docker.io/cloudpirates | mongodb | 0.18.1 |
+| oci://registry-1.docker.io/cloudpirates | valkey | 0.24.3 |
+
+## Installation
+
+Add the Eclipse CSI Helm repository:
+
+```console
+helm repo add eclipse-csi https://eclipse-csi.github.io/helm-charts
+helm repo update
+```
+
+Install the chart with the release name `otterdog`:
+
+```console
+helm install otterdog eclipse-csi/otterdog \
+  --namespace otterdog --create-namespace
+```
+
+Provide your own configuration with a values file:
+
+```console
+helm install otterdog eclipse-csi/otterdog \
+  --namespace otterdog --create-namespace \
+  -f my-values.yaml
+```
+
+Or override individual values on the command line:
+
+```console
+helm install otterdog eclipse-csi/otterdog \
+  --namespace otterdog --create-namespace \
+  --set config.configOwner=MyOrg \
+  --set github.appId=123456
+```
+
+Upgrade an existing release:
+
+```console
+helm upgrade otterdog eclipse-csi/otterdog \
+  --namespace otterdog -f my-values.yaml
+```
+
+Uninstall the release:
+
+```console
+helm uninstall otterdog --namespace otterdog
+```
+
+> **Note:** the `mongodb`, `valkey` and `ghproxy` sub-charts are enabled by default,
+> and the MongoDB, Valkey and ghproxy connection endpoints are auto-derived from the
+> sub-chart service names — no manual host configuration is needed in the common case.
+> Secrets must be supplied either through `values.yaml` or through Vault — see the
+> [Secrets](#secrets) section below. See the [Values](#values) section for all options.
+
+## Development mode
+
+For local development you can run the chart entirely self-contained: no Vault, all
+dependencies (MongoDB, Valkey, ghproxy) deployed by the sub-charts, and debug logging
+enabled. Secrets are provided inline in your values file (dev only — never commit real
+secrets).
+
+Create a `dev-values.yaml`:
+
+```yaml
+# vault disabled → secrets come from this file
+vault:
+  enabled: false
+
+config:
+  # verbose logging
+  debug: true
+  configOwner: "MyOrg"
+  configRepo: "otterdog-configs"
+  configPath: "otterdog.json"
+  configToken: "ghp_xxx"
+  # mongoHost / mongoPort / valkeyUri / ghProxyUri are auto-derived from the
+  # sub-chart services, so they can be left empty in dev.
+
+github:
+  appId: "123456"
+  # PEM content of the GitHub App private key
+  appPrivateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
+  webhookSecret: "dev-webhook-secret"
+
+# in-cluster dependencies (enabled by default, shown here for clarity)
+mongodb:
+  enabled: true
+  auth:
+    rootPassword: changeme
+    appUserPassword: changeme
+valkey:
+  enabled: true
+ghproxy:
+  enabled: true
+```
+
+Install into a dev namespace:
+
+```console
+helm install otterdog eclipse-csi/otterdog \
+  --namespace otterdog-dev --create-namespace \
+  -f dev-values.yaml
+```
+
+Port-forward the service to reach the web app locally:
+
+```console
+kubectl -n otterdog-dev port-forward svc/otterdog 5000:5000
+```
+
+Then open <http://localhost:5000>.
+
+To iterate quickly on chart changes, render the manifests without installing:
+
+```console
+helm template otterdog . -f dev-values.yaml | less
+```
+
+## Secrets
+
+Secrets can be provided in two mutually exclusive ways, controlled by `vault.enabled`.
+
+### Non-Vault mode (`vault.enabled: false`)
+
+Secret values are read from `values.yaml` and rendered into dedicated Kubernetes
+`Secret` objects by `templates/secrets.yaml`. This is intended for local/dev use only —
+do not commit real secrets.
+
+### Vault mode (`vault.enabled: true`)
+
+Secrets are synced from HashiCorp Vault by the
+[Vault Secrets Operator (VSO)](https://developer.hashicorp.com/vault/docs/platform/k8s/vso).
+`templates/vault-static-secret.yaml` creates one `VaultStaticSecret` per secret, each syncing
+into its own Kubernetes `Secret`.
+
+All keys are read from a single Vault KV v2 entry:
+
+```
+<vault.secretMount>/data/<vault.secretPath>     e.g. csi/data/otterdog/dev
+```
+
+The following keys must exist in that Vault entry:
+
+| Vault key | Kubernetes Secret (VSO destination) | Consumed as |
+| --------- | ----------------------------------- | ----------- |
+| `otterdog_config_token` | `<release>-config-token` | env `OTTERDOG_CONFIG_TOKEN` |
+| `github_webhook_secret` | `<release>-webhook-secret` | env `GITHUB_WEBHOOK_SECRET` |
+| `github_app_key` | `<release>-app-private-key` | file `/run/secrets/app-private-key/app.key` (env `GITHUB_APP_PRIVATE_KEY`) |
+| `dependency_track_token` | `<release>-dependency-track-token` | env `DEPENDENCY_TRACK_TOKEN` |
+| `mongodb_root_password` | `<release>-mongodb-root-credentials` | MongoDB subchart root password; also embedded in `MONGO_URI` when no `mongodb.customUsers` are configured |
+| `mongodb_app_password` | `<release>-mongodb-app-credentials` (key `CUSTOM_PASSWORD`) and `<release>-mongo-uri` (env `MONGO_URI`) | MongoDB app user password |
+| `valkey_password` | `<release>-valkey-credentials` | Valkey subchart password (used by the `valkey` sub-chart itself via `auth.existingSecret`/`auth.existingSecretPasswordKey`); only synced when `valkey.enabled` and `valkey.auth.enabled` |
+| `valkey_password` | `<release>-valkey-uri` (env `REDIS_URI`) | Same password, embedded in the app's `REDIS_URI` when `valkey.auth.enabled`; when `valkey.auth.enabled: false`, `REDIS_URI` is still created but with no credentials |
+
+Notes:
+
+- `MONGO_URI` is built by one of three mutually exclusive `VaultStaticSecret` variants,
+  selected automatically based on `mongodb.customUsers` / `mongodb.auth.enabled`:
+  - `mongodb.customUsers` configured → uses `mongodb_app_password`, with
+    `authSource=<mongodb.customUsers[0].database>` (default `otterdog`).
+  - no `customUsers`, `mongodb.auth.enabled: true` → uses `mongodb_root_password`, with
+    `authSource=admin` — MongoDB's root user always lives in the `admin` database,
+    regardless of `config.mongoDatabase`.
+  - `mongodb.auth.enabled: false` → no credentials at all in `MONGO_URI`.
+- `mongodb_root_password` is also used by the MongoDB subchart to bootstrap the root user
+  (and the app user, when `mongodb.customUsers` is configured).
+- Similarly, `valkey_password` has two destinations: `<release>-valkey-credentials` bootstraps
+  the Valkey server itself (subchart-consumed), while `<release>-valkey-uri` is what the
+  otterdog app actually connects with (`REDIS_URI`) — keep both in sync if you rotate it
+  manually instead of just updating the Vault value.
+- Vault connection settings (auth path, role, mount and path) are configured under the
+  `vault.*` values below.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| replicaCount | int | `1` | Number of replicas to deploy |
+| image.repository | string | `"ghcr.io/eclipse-csi/otterdog"` | Image repository |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.tag | string | `""` | Image tag (defaults to the chart appVersion if empty) |
+| imagePullSecrets | list | `[]` | Image pull secrets |
+| nameOverride | string | `""` | Name override for the chart |
+| fullnameOverride | string | `""` | Full name override for the chart |
+| config.debug | bool | `false` | Enable debug mode |
+| config.baseUrl | string | `"http://0.0.0.0:5000"` | Base URL for the application |
+| config.cacheControl | bool | `false` | Enable cache control |
+| config.appRoot | string | `"/app/work"` | Application root directory |
+| config.mongoHost | string | `""` | MongoDB host (optional — auto-derived: `<release>-mongodb.<namespace>.svc.cluster.local`) |
+| config.mongoPort | string | `""` | MongoDB port (optional — auto-derived: `27017`) |
+| config.mongoDatabase | string | `"otterdog"` | MongoDB database name |
+| config.mongoUsername | string | `""` | MongoDB username for the auto-derived URI (optional; defaults to customUsers[0].name) |
+| config.mongoPassword | string | `""` | MongoDB password for the auto-derived URI (optional; defaults to customUsers[0].password) |
+| config.valkeyUri | string | `""` | Redis URI (optional — auto-derived: `redis://<release>-valkey.<namespace>.svc.cluster.local:6379`) |
+| config.valkeyUsername | string | `""` | Redis/Valkey username for the auto-derived URI (optional; ignored when valkeyUri is set) |
+| config.valkeyPassword | string | `""` | Redis/Valkey password for the auto-derived URI (optional; ignored when valkeyUri is set) |
+| config.ghProxyUri | string | `""` | GitHub proxy URI (optional — auto-derived: `http://<release>-ghproxy.<namespace>.svc.cluster.local:8888`) |
+| config.configOwner | string | `""` | GitHub organization hosting the otterdog.json, e.g. MyOrg (https://github.com/MyOrg) |
+| config.configRepo | string | `".otterdog"` | GitHub repo hosting the otterdog.json, e.g. (https://github.com/MyOrg/.otterdog) |
+| config.configPath | string | `"/app/otterdog.json"` | Path to the otterdog.json, e.g. otterdog.json |
+| config.configToken | string | `""` | A valid GitHub token, no need for any permissions, just for rate limit purposes |
+| config.dependencyTrackUrl | string | `""` | Dependency-Track URL |
+| config.dependencyTrackToken | string | `""` | A valid Dependency-Track token, no need for any permissions, just for rate limit purposes |
+| initJob.enabled | bool | `true` | Run a Helm post-install/post-upgrade hook Job that calls /internal/init (refreshes org configs, policies and blueprints) after every install/upgrade. |
+| initJob.backoffLimit | int | `4` | Number of retries before the Job is considered failed |
+| policies.enabled | bool | `true` | Enable the policy check CronJob |
+| policies.schedule | string | `"*/5 * * * *"` | Cron schedule for the policy check |
+| policies.batchSize | int | `10` | Number of checks per invocation |
+| github.adminTeams | string | `"otterdog-admins"` | GitHub admin teams |
+| github.webhookEndpoint | string | `"/github-webhook/receive\"\""` | GitHub webhook endpoint |
+| github.webhookSecret | string | `""` | GitHub webhook secret |
+| github.webhookValidationContext | string | `""` | GitHub webhook validation context |
+| github.webhookSyncContext | string | `""` | GitHub webhook sync context |
+| github.appId | string | `""` | GitHub app ID |
+| github.appPrivateKey | string | `""` | GitHub app private key |
+| vault.enabled | bool | `false` | Enable Vault Secrets Operator (VSO) integration for secrets |
+| vault.tlsSkipVerify | bool | `true` | Skip TLS verification when connecting to Vault |
+| vault.authPath | string | `""` | Vault Kubernetes auth path, e.g. auth/kubernetes-<instance>-<env>-<namespace> |
+| vault.role | string | `""` | Vault role for authentication, e.g. <instance>-<env>_<namespace>_role |
+| vault.secretMount | string | `"csi"` | Vault KV v2 secrets engine mount path, e.g. csi |
+| vault.secretPath | string | `"otterdog/dev"` | Full path inside the mount, e.g. otterdog/<env> → csi/data/otterdog/staging |
+| vault.serviceAccountName | string | `"secrets-manager-sa"` | Service account name for the Vault Kubernetes auth method (optional; defaults to "secrets-manager-sa") |
+| vault.operator | object | `{"refreshAfter":"30s"}` | VSO operator configuration |
+| vault.operator.refreshAfter | string | `"30s"` | How often VSO syncs the secret from Vault (e.g. 30s, 1m) |
+| ingress.enabled | bool | `true` | Enable ingress |
+| ingress.defaultBackend.enabled | bool | `false` | Enable default backend |
+| ingress.className | string | `"nginx"` | Ingress class name |
+| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.hosts | list | `[{"host":"otterdog.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | Ingress hosts |
+| router.enabled | bool | `false` | Enable router (OpenShift Route) |
+| router.tls.enabled | bool | `true` | Enable TLS termination on the route |
+| router.tls.termination | string | `"edge"` | TLS termination type (edge, passthrough, reencrypt) |
+| router.tls.insecureEdgeTerminationPolicy | string | `"Redirect"` | Behavior for insecure (HTTP) traffic on a TLS route |
+| protectInit.path | string | `"/internal/"` | Path restricted to this dedicated Ingress/Route |
+| protectInit.ingress.enabled | bool | `false` | Enable a dedicated Ingress restricted to protectInit.path |
+| protectInit.ingress.className | string | `"nginx"` | Ingress class name |
+| protectInit.ingress.annotations | object | `{}` | Ingress annotations (e.g. IP allowlist, auth) |
+| protectInit.ingress.host | string | `"otterdog.local"` | Host for the dedicated Ingress |
+| protectInit.router.enabled | bool | `false` | Enable a dedicated OpenShift Route restricted to protectInit.path |
+| protectInit.router.host | string | `""` | Host for the dedicated Route (defaults to router.host when empty) |
+| protectInit.router.annotations | object | `{}` | Route annotations (e.g. IP allowlist, auth) |
+| protectInit.router.tls.enabled | bool | `true` | Enable TLS termination on the route |
+| protectInit.router.tls.termination | string | `"edge"` | TLS termination type (edge, passthrough, reencrypt) |
+| protectInit.router.tls.insecureEdgeTerminationPolicy | string | `"Redirect"` | Behavior for insecure (HTTP) traffic on a TLS route |
+| service.type | string | `"NodePort"` | Service type |
+| service.port | int | `5000` | Service port |
+| serviceAccount.create | bool | `true` | Create a service account |
+| serviceAccount.automount | bool | `true` | Automount the service account token |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.name | string | `""` | Service account name |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{}` | Pod security context |
+| securityContext | object | `{}` | Container security context |
+| resources | object | `{}` | Resource requests and limits for the otterdog container |
+| initContainers | list | `[]` | Override the default init containers (wait-for-mongodb, wait-for-redis) |
+| autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler |
+| autoscaling.minReplicas | int | `1` | Minimum number of replicas |
+| autoscaling.maxReplicas | int | `100` | Maximum number of replicas |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
+| volumes | list | `[]` | Additional volumes on the output Deployment definition |
+| volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| tolerations | list | `[]` | Tolerations for pod assignment |
+| affinity | object | `{}` | Affinity rules for pod assignment |
+| startupProbe | object | `{"failureThreshold":24,"httpGet":{"path":"/internal/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":5,"timeoutSeconds":3}` | Startup probe: gates liveness/readiness until the app is listening, so slow starts don't trigger "connection refused" failures or premature restarts. |
+| startupProbe.httpGet.path | string | `"/internal/health"` | Startup probe path |
+| startupProbe.httpGet.port | string | `"http"` | Startup probe port |
+| startupProbe.initialDelaySeconds | int | `5` | Delay before the first startup check |
+| startupProbe.periodSeconds | int | `5` | How often to probe during startup |
+| startupProbe.timeoutSeconds | int | `3` | Probe timeout |
+| startupProbe.failureThreshold | int | `24` | Failures allowed before the container is restarted (5s * 24 = up to 120s to start) |
+| livenessProbe.httpGet.path | string | `"/internal/health"` | Liveness probe path |
+| livenessProbe.httpGet.port | string | `"http"` | Liveness probe port |
+| livenessProbe.periodSeconds | int | `15` | How often to probe |
+| livenessProbe.timeoutSeconds | int | `3` | Probe timeout |
+| livenessProbe.failureThreshold | int | `3` | Consecutive failures before the container is restarted |
+| readinessProbe.httpGet.path | string | `"/internal/health"` | Readiness probe path |
+| readinessProbe.httpGet.port | string | `"http"` | Readiness probe port |
+| readinessProbe.initialDelaySeconds | int | `5` | Delay before the first readiness check |
+| readinessProbe.periodSeconds | int | `10` | How often to probe |
+| readinessProbe.timeoutSeconds | int | `3` | Probe timeout |
+| readinessProbe.failureThreshold | int | `3` | Consecutive failures before the pod is marked unready |
+| readinessProbe.successThreshold | int | `1` | Consecutive successes before the pod is marked ready |
+| mongodb.enabled | bool | `true` | Enable MongoDB subchart (cloudpirates/mongodb OCI chart) |
+| mongodb.auth.enabled | bool | `true` | Enable MongoDB authentication |
+| mongodb.auth.rootUsername | string | `"root"` | MongoDB root username |
+| mongodb.auth.rootPassword | string | `"changeme"` | MongoDB root password (set to "" when vault.enabled; the subchart uses this to bootstrap the app user) |
+| mongodb.auth.existingSecret | string | `"{{ printf \"%s-mongodb-root-credentials\" .Release.Name }}"` |  |
+| mongodb.auth.existingSecretPasswordKey | string | `"mongodb_root_password"` |  |
+| mongodb.customUsers | list | `[{"database":"otterdog","existingSecret":"{{ printf \"%s-mongodb-app-credentials\" .Release.Name }}","name":"otterdog","password":"changeme","roles":["readWrite"],"secretKeys":{"database":"CUSTOM_DB","name":"CUSTOM_USER","password":"CUSTOM_PASSWORD"}}]` | Name of the K8s Secret holding the app user credentials for vault mode. Created by vault-static-secret.yaml when vault.enabled. Must match customUsers[0].existingSecret — set both to the same value. Non-vault mode: leave password set and existingSecret commented out. Vault mode: comment out password and uncomment existingSecret/secretKeys. |
+| mongodb.persistence | object | `{"accessMode":"ReadWriteOnce","enabled":true,"size":"8Gi","storageClass":""}` | MongoDB persistence (PersistentVolumeClaim) configuration, passed to the mongodb subchart |
+| mongodb.persistence.enabled | bool | `true` | Enable a PersistentVolumeClaim for MongoDB data |
+| mongodb.persistence.storageClass | string | `""` | StorageClass for the PVC (empty = cluster default) |
+| mongodb.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the PVC |
+| mongodb.persistence.size | string | `"8Gi"` | Size of the PVC |
+| valkey.enabled | bool | `true` | Enable Valkey subchart (cloudpirates/valkey OCI chart) |
+| valkey.auth.enabled | bool | `true` | Enable Valkey authentication |
+| valkey.auth.password | string | `"changeme"` |  |
+| valkey.persistence.enabled | bool | `true` |  |
+| valkey.persistence.size | string | `"8Gi"` |  |
+| valkey.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| ghproxy.enabled | bool | `true` | Enable ghproxy |
+
+<!-- x-release-please-start-version -->
+[version-badge]: https://img.shields.io/badge/Version-1.1.12%2Dinformational?style=flat-square
+<!-- x-release-please-end -->

--- a/charts/otterdog/README.md.gotmpl
+++ b/charts/otterdog/README.md.gotmpl
@@ -1,0 +1,194 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+![Version: {{ template "chart.version" . }}][version-badge] <!-- x-release-please-version -->
+{{ template "chart.typeBadge" . }}
+{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installation
+
+Add the Eclipse CSI Helm repository:
+
+```console
+helm repo add eclipse-csi https://eclipse-csi.github.io/helm-charts
+helm repo update
+```
+
+Install the chart with the release name `otterdog`:
+
+```console
+helm install otterdog eclipse-csi/{{ template "chart.name" . }} \
+  --namespace otterdog --create-namespace
+```
+
+Provide your own configuration with a values file:
+
+```console
+helm install otterdog eclipse-csi/{{ template "chart.name" . }} \
+  --namespace otterdog --create-namespace \
+  -f my-values.yaml
+```
+
+Or override individual values on the command line:
+
+```console
+helm install otterdog eclipse-csi/{{ template "chart.name" . }} \
+  --namespace otterdog --create-namespace \
+  --set config.configOwner=MyOrg \
+  --set github.appId=123456
+```
+
+Upgrade an existing release:
+
+```console
+helm upgrade otterdog eclipse-csi/{{ template "chart.name" . }} \
+  --namespace otterdog -f my-values.yaml
+```
+
+Uninstall the release:
+
+```console
+helm uninstall otterdog --namespace otterdog
+```
+
+> **Note:** the `mongodb`, `valkey` and `ghproxy` sub-charts are enabled by default,
+> and the MongoDB, Valkey and ghproxy connection endpoints are auto-derived from the
+> sub-chart service names — no manual host configuration is needed in the common case.
+> Secrets must be supplied either through `values.yaml` or through Vault — see the
+> [Secrets](#secrets) section below. See the [Values](#values) section for all options.
+
+## Development mode
+
+For local development you can run the chart entirely self-contained: no Vault, all
+dependencies (MongoDB, Valkey, ghproxy) deployed by the sub-charts, and debug logging
+enabled. Secrets are provided inline in your values file (dev only — never commit real
+secrets).
+
+Create a `dev-values.yaml`:
+
+```yaml
+# vault disabled → secrets come from this file
+vault:
+  enabled: false
+
+config:
+  # verbose logging
+  debug: true
+  configOwner: "MyOrg"
+  configRepo: "otterdog-configs"
+  configPath: "otterdog.json"
+  configToken: "ghp_xxx"
+  # mongoHost / mongoPort / valkeyUri / ghProxyUri are auto-derived from the
+  # sub-chart services, so they can be left empty in dev.
+
+github:
+  appId: "123456"
+  # PEM content of the GitHub App private key
+  appPrivateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
+  webhookSecret: "dev-webhook-secret"
+
+# in-cluster dependencies (enabled by default, shown here for clarity)
+mongodb:
+  enabled: true
+  auth:
+    rootPassword: changeme
+    appUserPassword: changeme
+valkey:
+  enabled: true
+ghproxy:
+  enabled: true
+```
+
+Install into a dev namespace:
+
+```console
+helm install otterdog eclipse-csi/{{ template "chart.name" . }} \
+  --namespace otterdog-dev --create-namespace \
+  -f dev-values.yaml
+```
+
+Port-forward the service to reach the web app locally:
+
+```console
+kubectl -n otterdog-dev port-forward svc/otterdog 5000:5000
+```
+
+Then open <http://localhost:5000>.
+
+To iterate quickly on chart changes, render the manifests without installing:
+
+```console
+helm template otterdog . -f dev-values.yaml | less
+```
+
+## Secrets
+
+Secrets can be provided in two mutually exclusive ways, controlled by `vault.enabled`.
+
+### Non-Vault mode (`vault.enabled: false`)
+
+Secret values are read from `values.yaml` and rendered into dedicated Kubernetes
+`Secret` objects by `templates/secrets.yaml`. This is intended for local/dev use only —
+do not commit real secrets.
+
+### Vault mode (`vault.enabled: true`)
+
+Secrets are synced from HashiCorp Vault by the
+[Vault Secrets Operator (VSO)](https://developer.hashicorp.com/vault/docs/platform/k8s/vso).
+`templates/vault-static-secret.yaml` creates one `VaultStaticSecret` per secret, each syncing
+into its own Kubernetes `Secret`.
+
+All keys are read from a single Vault KV v2 entry:
+
+```
+<vault.secretMount>/data/<vault.secretPath>     e.g. csi/data/otterdog/dev
+```
+
+The following keys must exist in that Vault entry:
+
+| Vault key | Kubernetes Secret (VSO destination) | Consumed as |
+| --------- | ----------------------------------- | ----------- |
+| `otterdog_config_token` | `<release>-config-token` | env `OTTERDOG_CONFIG_TOKEN` |
+| `github_webhook_secret` | `<release>-webhook-secret` | env `GITHUB_WEBHOOK_SECRET` |
+| `github_app_key` | `<release>-app-private-key` | file `/run/secrets/app-private-key/app.key` (env `GITHUB_APP_PRIVATE_KEY`) |
+| `dependency_track_token` | `<release>-dependency-track-token` | env `DEPENDENCY_TRACK_TOKEN` |
+| `mongodb_root_password` | `<release>-mongodb-root-credentials` | MongoDB subchart root password; also embedded in `MONGO_URI` when no `mongodb.customUsers` are configured |
+| `mongodb_app_password` | `<release>-mongodb-app-credentials` (key `CUSTOM_PASSWORD`) and `<release>-mongo-uri` (env `MONGO_URI`) | MongoDB app user password |
+| `valkey_password` | `<release>-valkey-credentials` | Valkey subchart password (used by the `valkey` sub-chart itself via `auth.existingSecret`/`auth.existingSecretPasswordKey`); only synced when `valkey.enabled` and `valkey.auth.enabled` |
+| `valkey_password` | `<release>-valkey-uri` (env `REDIS_URI`) | Same password, embedded in the app's `REDIS_URI` when `valkey.auth.enabled`; when `valkey.auth.enabled: false`, `REDIS_URI` is still created but with no credentials |
+
+Notes:
+
+- `MONGO_URI` is built by one of three mutually exclusive `VaultStaticSecret` variants,
+  selected automatically based on `mongodb.customUsers` / `mongodb.auth.enabled`:
+  - `mongodb.customUsers` configured → uses `mongodb_app_password`, with
+    `authSource=<mongodb.customUsers[0].database>` (default `otterdog`).
+  - no `customUsers`, `mongodb.auth.enabled: true` → uses `mongodb_root_password`, with
+    `authSource=admin` — MongoDB's root user always lives in the `admin` database,
+    regardless of `config.mongoDatabase`.
+  - `mongodb.auth.enabled: false` → no credentials at all in `MONGO_URI`.
+- `mongodb_root_password` is also used by the MongoDB subchart to bootstrap the root user
+  (and the app user, when `mongodb.customUsers` is configured).
+- Similarly, `valkey_password` has two destinations: `<release>-valkey-credentials` bootstraps
+  the Valkey server itself (subchart-consumed), while `<release>-valkey-uri` is what the
+  otterdog app actually connects with (`REDIS_URI`) — keep both in sync if you rotate it
+  manually instead of just updating the Vault value.
+- Vault connection settings (auth path, role, mount and path) are configured under the
+  `vault.*` values below.
+
+{{ template "chart.valuesSection" . }}
+
+<!-- x-release-please-start-version -->
+[version-badge]: https://img.shields.io/badge/Version-{{ template "chart.version" . }}%2Dinformational?style=flat-square
+<!-- x-release-please-end -->

--- a/charts/otterdog/templates/_helpers.tpl
+++ b/charts/otterdog/templates/_helpers.tpl
@@ -24,6 +24,27 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Image pull policy. Forces "Always" when image.tag is "dev" (mutable/floating tag),
+otherwise uses image.pullPolicy as configured.
+*/}}
+{{- define "webapp.image.pullPolicy" -}}
+{{- if eq .Values.image.tag "dev" -}}
+Always
+{{- else -}}
+{{- .Values.image.pullPolicy -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name for the dedicated Ingress/Route restricted to protectInit.path.
+Format: otterdog-protect-init-<env>, where <env> is derived by stripping the
+"otterdog-" release-name prefix (releases follow <chart>-<env>, e.g. otterdog-staging).
+*/}}
+{{- define "otterdog.protectInit.fullname" -}}
+{{- printf "otterdog-protect-init-%s" (trimPrefix "otterdog-" .Release.Name) -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "webapp.chart" -}}
@@ -62,49 +83,299 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Extract Redis host from URI
+Valkey host.
+Auto-derived from the valkey subchart service (<release>-valkey.<namespace>).
+Override with config.valkeyUri.
 */}}
-{{- define "otterdog.redis.host" -}}
-{{- $uri := .Values.config.redisUri | default "" -}}
-{{- /* Try extracting host after @ if auth is present */ -}}
+{{- define "otterdog.valkey.host" -}}
+{{- if .Values.config.valkeyUri -}}
+{{- $uri := .Values.config.valkeyUri -}}
 {{- $host := regexFind "@([^:/]+)" $uri | trimPrefix "@" -}}
-{{- /* If no auth, get the host directly after scheme or start of string */ -}}
-{{- if not $host }}
+{{- if not $host -}}
 {{- $host = regexFind "^([^:@/]+)" (regexReplaceAll "^redis://(.*)" $uri "${1}") -}}
-{{- end }}
+{{- end -}}
 {{- $host -}}
+{{- else -}}
+{{- printf "%s-valkey.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- end -}}
 {{- end -}}
 
 
 {{/*
-Extract Redis port from URI
+Valkey port.
+Auto-derived as 6379, or parsed from config.valkeyUri if set.
 */}}
-{{- define "otterdog.redis.port" -}}
-{{- $uri := .Values.config.redisUri | default "" -}}
-{{- $port := regexFind ":([0-9]+)$" $uri | trimPrefix ":" -}}
-{{- default "6379" $port -}}
+{{- define "otterdog.valkey.port" -}}
+{{- if .Values.config.valkeyUri -}}
+{{- regexFind ":([0-9]+)$" .Values.config.valkeyUri | trimPrefix ":" | default "6379" -}}
+{{- else -}}
+{{- "6379" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Full Valkey URI.
+Auto-derived from the valkey subchart service (<release>-valkey.<namespace>).
+When valkeyUri is not set, valkeyUsername/valkeyPassword are injected as credentials.
+Override with config.valkeyUri.
+*/}}
+{{- define "otterdog.valkey.uri" -}}
+{{- if .Values.config.valkeyUri -}}
+{{- .Values.config.valkeyUri -}}
+{{- else -}}
+{{- $pass := .Values.config.valkeyPassword -}}
+{{- if and (not $pass) .Values.valkey.auth.enabled -}}
+{{- $pass = .Values.valkey.auth.password -}}
+{{- end -}}
+{{- $user := .Values.config.valkeyUsername | default (ternary "default" "" (not (empty $pass))) -}}
+{{- $auth := "" -}}
+{{- if and $user $pass -}}
+{{- $auth = printf "%s:%s@" $user $pass -}}
+{{- else if $user -}}
+{{- $auth = printf "%s@" $user -}}
+{{- end -}}
+{{- printf "redis://%s%s:%s" $auth (include "otterdog.valkey.host" .) (include "otterdog.valkey.port" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Extract MongoDB host from URI
+Builds the redis_uri text value for a VSO transformation template.
+When valkey.auth.enabled, the password placeholder {{ .Secrets.valkey_password }}
+is left as a literal string for VSO to resolve at sync time.
+When auth is disabled, returns a fully static URI from Helm values.
+  username (optional) : config.valkeyUsername
+  host / port         : otterdog.valkey.host / otterdog.valkey.port
+*/}}
+{{- define "otterdog.valkey.vso.uri" -}}
+{{- if .Values.valkey.auth.enabled -}}
+{{- $user := .Values.config.valkeyUsername | default "default" -}}
+{{- printf "redis://%s:{{ .Secrets.valkey_password }}@%s:%s"
+    $user
+    (include "otterdog.valkey.host" .)
+    (include "otterdog.valkey.port" .) -}}
+{{- else -}}
+{{- include "otterdog.valkey.uri" . -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+GHProxy host.
+Auto-derived from the ghproxy subchart service (<release>-ghproxy.<namespace>).
+Override with config.ghProxyUri.
+*/}}
+{{- define "otterdog.ghproxy.host" -}}
+{{- if .Values.config.ghProxyUri -}}
+{{- regexFind "^([^:/]+)" (regexReplaceAll "^https?://(.*)" .Values.config.ghProxyUri "${1}") -}}
+{{- else -}}
+{{- printf "%s-ghproxy.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+GHProxy port.
+Auto-derived as 8888, or parsed from config.ghProxyUri if set.
+*/}}
+{{- define "otterdog.ghproxy.port" -}}
+{{- if .Values.config.ghProxyUri -}}
+{{- regexFind ":([0-9]+)" .Values.config.ghProxyUri | trimPrefix ":" | default "8888" -}}
+{{- else -}}
+{{- "8888" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Full GHProxy URI.
+Auto-derived from the ghproxy subchart service (<release>-ghproxy.<namespace>).
+Override with config.ghProxyUri.
+*/}}
+{{- define "otterdog.ghproxy.uri" -}}
+{{- .Values.config.ghProxyUri | default (printf "http://%s:%s" (include "otterdog.ghproxy.host" .) (include "otterdog.ghproxy.port" .)) -}}
+{{- end -}}
+
+{{/*
+MongoDB host.
+Auto-derived from the mongodb subchart service (<release>-mongodb.<namespace>).
+Override with config.mongoHost.
 */}}
 {{- define "otterdog.mongodb.host" -}}
-{{- $uri := .Values.config.mongoUri | default "" -}}
-{{- /* Try extracting host after @ if auth is present */ -}}
-{{- $host := regexFind "@([^:/]+)" $uri | trimPrefix "@" -}}
-{{- /* If no auth, get the host directly after scheme or start of string */ -}}
-{{- if not $host }}
-{{- $host = regexFind "^([^:@/]+)" (regexReplaceAll "^mongodb://(.*)" $uri "${1}") -}}
-{{- end }}
-{{- $host -}}
+{{- .Values.config.mongoHost | default (printf "%s-mongodb.%s.svc.cluster.local" .Release.Name .Release.Namespace) -}}
 {{- end -}}
 
 
 {{/*
-Extract MongoDB port from URI
+MongoDB port.
+Override with config.mongoPort.
 */}}
 {{- define "otterdog.mongodb.port" -}}
-{{- $uri := .Values.config.mongoUri | default "" -}}
-{{- $port := regexFind ":([0-9]+)$" $uri | trimPrefix ":" -}}
-{{- default "27017" $port -}}
+{{- .Values.config.mongoPort | default "27017" -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret created by the Vault Secrets Operator.
+Override with vault.operator.destinationSecret, otherwise defaults to <fullname>-vault-secrets.
+*/}}
+{{- define "otterdog.vault.secretName" -}}
+{{- default (printf "%s-vault-secrets" (include "webapp.fullname" .)) .Values.vault.operator.destinationSecret -}}
+{{- end -}}
+
+{{/*
+Name of the dedicated MongoDB credentials Secret created by VSO.
+Used by the mongodb subchart as existingSecret when vault is enabled.
+*/}}
+{{- define "otterdog.mongodb.credentialsSecretName" -}}
+{{- printf "%s-mongodb-credentials" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret holding the GitHub config token.
+*/}}
+{{- define "otterdog.secret.configToken" -}}
+{{- printf "%s-config-token" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret holding the GitHub webhook secret.
+*/}}
+{{- define "otterdog.secret.webhookSecret" -}}
+{{- printf "%s-webhook-secret" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret holding the GitHub App private key.
+*/}}
+{{- define "otterdog.secret.appPrivateKey" -}}
+{{- printf "%s-app-private-key" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret holding the Dependency-Track API token.
+*/}}
+{{- define "otterdog.secret.dependencyTrackToken" -}}
+{{- printf "%s-dependency-track-token" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret holding the MongoDB URI.
+*/}}
+{{- define "otterdog.secret.mongoUri" -}}
+{{- printf "%s-mongo-uri" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the Kubernetes Secret holding the Redis/Valkey URI.
+*/}}
+{{- define "otterdog.secret.redisUri" -}}
+{{- printf "%s-valkey-uri" (include "webapp.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Reusable guard for the first customUser entry (returns an empty dict if customUsers is nil or empty).
+*/}}
+{{- define "otterdog.mongodb.firstUser" -}}
+{{- $users := .Values.mongodb.customUsers | default list -}}
+{{- if gt (len $users) 0 -}}
+{{- index $users 0 | toJson -}}
+{{- else -}}
+{{- dict | toJson -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+MongoDB connection username with safe fallbacks.
+Priority: config.mongoUsername → customUsers[0].name → auth.rootUsername → ""
+*/}}
+{{- define "otterdog.mongodb.username" -}}
+{{- $user := include "otterdog.mongodb.firstUser" . | fromJson -}}
+{{- coalesce .Values.config.mongoUsername (get $user "name") .Values.mongodb.auth.rootUsername "" -}}
+{{- end -}}
+
+{{/*
+MongoDB database name with safe fallbacks.
+Priority: config.mongoDatabase → customUsers[0].database → "otterdog"
+*/}}
+{{- define "otterdog.mongodb.database" -}}
+{{- $user := include "otterdog.mongodb.firstUser" . | fromJson -}}
+{{- coalesce .Values.config.mongoDatabase (get $user "database") "otterdog" -}}
+{{- end -}}
+
+{{/*
+Auth source database for the mongo connection.
+customUsers  : the app user only exists in its own database → authSource = that database.
+root fallback (no customUsers) : MONGO_INITDB_ROOT_USERNAME/PASSWORD always create the root
+  user in "admin", regardless of config.mongoDatabase → authSource = "admin".
+*/}}
+{{- define "otterdog.mongodb.authSource" -}}
+{{- $user := include "otterdog.mongodb.firstUser" . | fromJson -}}
+{{- if get $user "name" -}}
+{{- include "otterdog.mongodb.database" . -}}
+{{- else -}}
+admin
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build the full MongoDB connection URI with safe fallbacks.
+Priority:
+  username : config.mongoUsername → customUsers[0].name → auth.rootUsername → ""
+  password : config.mongoPassword → customUsers[0].password → auth.rootPassword → ""
+  database : config.mongoDatabase → customUsers[0].database → "otterdog"
+customUsers may be nil or empty — all accesses are guarded.
+mongodb.auth.enabled=false → no credentials in the URI at all.
+mongodb.auth.enabled=true  → credentials plus an explicit authSource (see otterdog.mongodb.authSource).
+*/}}
+{{- define "otterdog.mongodb.uri" -}}
+{{- if not .Values.mongodb.auth.enabled -}}
+{{- printf "mongodb://%s:%s/%s" (include "otterdog.mongodb.host" .) (include "otterdog.mongodb.port" .) (include "otterdog.mongodb.database" .) -}}
+{{- else -}}
+{{- $user := include "otterdog.mongodb.firstUser" . | fromJson -}}
+{{- $username := coalesce .Values.config.mongoUsername (get $user "name") .Values.mongodb.auth.rootUsername "" -}}
+{{- $password := coalesce .Values.config.mongoPassword (get $user "password") .Values.mongodb.auth.rootPassword "" -}}
+{{- printf "mongodb://%s:%s@%s:%s/%s?authSource=%s"
+    $username $password
+    (include "otterdog.mongodb.host" .)
+    (include "otterdog.mongodb.port" .)
+    (include "otterdog.mongodb.database" .)
+    (include "otterdog.mongodb.authSource" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Builds the mongo_uri text for a VSO transformation template using the app-user password.
+The password placeholder {{ .Secrets.mongodb_app_password }} is left as a literal string
+for VSO to resolve at sync time. authSource is the app user's own database.
+*/}}
+{{- define "otterdog.mongodb.vso.uri.app" -}}
+{{- printf "mongodb://%s:{{ .Secrets.mongodb_app_password }}@%s:%s/%s?authSource=%s"
+    (include "otterdog.mongodb.username" .)
+    (include "otterdog.mongodb.host" .)
+    (include "otterdog.mongodb.port" .)
+    (include "otterdog.mongodb.database" .)
+    (include "otterdog.mongodb.database" .) -}}
+{{- end -}}
+
+{{/*
+Builds the mongo_uri text for a VSO transformation template using the root password.
+The password placeholder {{ .Secrets.mongodb_root_password }} is left as a literal string
+for VSO to resolve at sync time. authSource is always "admin": MONGO_INITDB_ROOT_USERNAME/PASSWORD
+always create the root user there, regardless of config.mongoDatabase.
+*/}}
+{{- define "otterdog.mongodb.vso.uri.root" -}}
+{{- printf "mongodb://%s:{{ .Secrets.mongodb_root_password }}@%s:%s/%s?authSource=admin"
+    (include "otterdog.mongodb.username" .)
+    (include "otterdog.mongodb.host" .)
+    (include "otterdog.mongodb.port" .)
+    (include "otterdog.mongodb.database" .) -}}
+{{- end -}}
+
+{{/*
+Builds the mongo_uri text for a VSO transformation template with no credentials at all,
+used when mongodb.auth.enabled is false.
+*/}}
+{{- define "otterdog.mongodb.vso.uri.noauth" -}}
+{{- printf "mongodb://%s:%s/%s"
+    (include "otterdog.mongodb.host" .)
+    (include "otterdog.mongodb.port" .)
+    (include "otterdog.mongodb.database" .) -}}
 {{- end -}}

--- a/charts/otterdog/templates/cronjob-policy-check.yaml
+++ b/charts/otterdog/templates/cronjob-policy-check.yaml
@@ -7,10 +7,14 @@ metadata:
     {{- include "webapp.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.policies.schedule | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 300
+      backoffLimit: 1
       template:
         metadata:
           labels:

--- a/charts/otterdog/templates/deployment.yaml
+++ b/charts/otterdog/templates/deployment.yaml
@@ -38,20 +38,29 @@ spec:
         - name: wait-for-mongodb
           image: busybox:1.37
           command: ['sh', '-c', 'until nc -z {{ include "otterdog.mongodb.host" . }} {{ include "otterdog.mongodb.port" . }}; do echo "waiting for MongoDB..."; sleep 2; done;']      
-        - name: wait-for-redis
+        - name: wait-for-valkey
           image: busybox:1.37
-          command: ['sh', '-c', 'until nc -z {{ include "otterdog.redis.host" . }} {{ include "otterdog.redis.port" . }}; do echo "waiting for Redis..."; sleep 2; done;']
+          command: ['sh', '-c', 'until nc -z {{ include "otterdog.valkey.host" . }} {{ include "otterdog.valkey.port" . }}; do echo "waiting for Redis..."; sleep 2; done;']
+        {{- if .Values.ghproxy.enabled }}
+        - name: wait-for-ghproxy
+          image: busybox:1.37
+          command: ['sh', '-c', 'until nc -z {{ include "otterdog.ghproxy.host" . }} {{ include "otterdog.ghproxy.port" . }}; do echo "waiting for ghproxy..."; sleep 2; done;']
+        {{- end }}
       {{- end }}     
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ include "webapp.image.pullPolicy" . }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -59,27 +68,15 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - name: workdir
+              mountPath: {{ .Values.config.appRoot | quote }}
+              readOnly: false
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if .Values.config.configToken }}
-            - name: config-token-volume
-              mountPath: /run/secrets/config-token
-              readOnly: true
-            {{- end }}
-            {{- if .Values.github.webhookSecret }}
-            - name: webhook-secret-volume
-              mountPath: /run/secrets/webhook-secret
-              readOnly: true
-            {{- end }}
-            {{- if .Values.github.appPrivateKey }}
-            - name: app-private-key-volume
+            {{- if or .Values.vault.enabled .Values.github.appPrivateKey }}
+            - name: app-private-key
               mountPath: /run/secrets/app-private-key
-              readOnly: true
-            {{- end }}
-            {{- if .Values.config.deploymentTrackToken }}
-            - name: dependency-track-token-volume
-              mountPath: /run/secrets/dependency-track-token
               readOnly: true
             {{- end }}
           env:
@@ -92,11 +89,17 @@ spec:
             - name: APP_ROOT
               value: {{ .Values.config.appRoot | quote }}
             - name: MONGO_URI
-              value: {{ .Values.config.mongoUri | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "otterdog.secret.mongoUri" . }}
+                  key: mongo_uri
             - name: REDIS_URI
-              value: {{ .Values.config.redisUri | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "otterdog.secret.redisUri" . }}
+                  key: redis_uri
             - name: GHPROXY_URI
-              value: {{ .Values.config.ghProxyUri | quote }}
+              value: {{ include "otterdog.ghproxy.uri" . | quote }}
             - name: OTTERDOG_CONFIG_OWNER
               value: {{ .Values.config.configOwner | quote }}
             - name: OTTERDOG_CONFIG_REPO
@@ -106,15 +109,15 @@ spec:
             - name: OTTERDOG_CONFIG_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: config-token-secret
-                  key: token
+                  name: {{ include "otterdog.secret.configToken" . }}
+                  key: otterdog_config_token
             - name: DEPENDENCY_TRACK_URL
               value: {{ .Values.config.dependencyTrackUrl | quote }}
             - name: DEPENDENCY_TRACK_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: dependency-track-token-secret
-                  key: token
+                  name: {{ include "otterdog.secret.dependencyTrackToken" . }}
+                  key: dependency_track_token
             - name: GITHUB_ADMIN_TEAMS
               value: {{ .Values.github.adminTeams | quote }}
             - name: WEBHOOK_ENDPOINT
@@ -122,8 +125,8 @@ spec:
             - name: GITHUB_WEBHOOK_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: webhook-secret
-                  key: secret
+                  name: {{ include "otterdog.secret.webhookSecret" . }}
+                  key: github_webhook_secret
             - name: GITHUB_WEBHOOK_VALIDATION_CONTEXT
               value: {{ .Values.github.webhookValidationContext | quote }}
             - name: GITHUB_WEBHOOK_SYNC_CONTEXT
@@ -133,28 +136,18 @@ spec:
             - name: GITHUB_APP_PRIVATE_KEY
               value: /run/secrets/app-private-key/app.key
       volumes:
+        - name: workdir
+          emptyDir: {}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.config.configToken }}
-        - name: config-token-volume
+        {{- if or .Values.vault.enabled .Values.github.appPrivateKey }}
+        - name: app-private-key
           secret:
-            secretName: config-token-secret
-        {{- end }}
-        {{- if .Values.github.webhookSecret }}
-        - name: webhook-secret-volume
-          secret:
-            secretName: webhook-secret
-        {{- end }}
-        {{- if .Values.github.appPrivateKey }}
-        - name: app-private-key-volume
-          secret:
-            secretName: app-private-key
-        {{- end }}
-        {{- if .Values.dependencyTrackToken }}
-        - name: dependency-track-token-volume
-          secret:
-            secretName: dependency-track-token-secret
+            secretName: {{ include "otterdog.secret.appPrivateKey" . }}
+            items:
+              - key: github_app_key
+                path: app.key
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/otterdog/templates/ingress-protect-init.yaml
+++ b/charts/otterdog/templates/ingress-protect-init.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.protectInit.ingress.enabled -}}
+{{- $name := include "otterdog.protectInit.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+  {{- with .Values.protectInit.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.protectInit.ingress.className }}
+  ingressClassName: {{ .Values.protectInit.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.protectInit.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.protectInit.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "webapp.fullname" . }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/charts/otterdog/templates/ingress.yaml
+++ b/charts/otterdog/templates/ingress.yaml
@@ -1,7 +1,3 @@
-{{- if and .Values.ingress.enabled .Values.router.enabled }}
-{{- fail "Both ingress and router cannot be enabled at the same time. Please enable only one of them." }}
-{{- end }}
-
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "webapp.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
@@ -70,36 +66,3 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
-
-{{- if .Values.router.enabled -}}
-{{- $fullName := include "webapp.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "webapp.labels" . | nindent 4 }}
-  {{- with .Values.router.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if .Values.router.host }}
-  host: {{ .Values.router.host }}
-  {{- end }}
-  {{- if .Values.router.path }}
-  path: {{ .Values.router.path }}
-  {{- end }}
-  port:
-    targetPort: {{ .Values.router.targetPort | default "http" }}
-  {{- if .Values.router.tls.enabled }}
-  tls:
-    termination: {{ .Values.router.tls.termination | default "edge" }}
-    insecureEdgeTerminationPolicy: {{ .Values.router.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
-  {{- end }}
-  to:
-    kind: Service
-    name: {{ $fullName }}
-    weight: {{ .Values.router.weight | default 100 }}
-{{- end -}}

--- a/charts/otterdog/templates/job-init-webapp.yaml
+++ b/charts/otterdog/templates/job-init-webapp.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.initJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "webapp.fullname" . }}-init
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.initJob.backoffLimit | default 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "webapp.selectorLabels" . | nindent 8 }}
+    spec:
+      initContainers:
+        - name: wait-for-otterdog
+          image: busybox:1.37
+          command: ['sh', '-c', 'until nc -z {{ include "webapp.fullname" . }} {{ .Values.service.port }}; do echo "waiting for otterdog..."; sleep 2; done;']
+      containers:
+        - name: init-webapp
+          image: curlimages/curl:8.10.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - curl -fsS --retry 10 --retry-connrefused --retry-delay 5 -I http://{{ include "webapp.fullname" . }}:{{ .Values.service.port }}/internal/init
+      restartPolicy: Never
+{{- end }}

--- a/charts/otterdog/templates/router-protect-init.yaml
+++ b/charts/otterdog/templates/router-protect-init.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.protectInit.router.enabled -}}
+{{- $name := include "otterdog.protectInit.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+  {{- with .Values.protectInit.router.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with (.Values.protectInit.router.host | default .Values.router.host) }}
+  host: {{ . }}
+  {{- end }}
+  path: {{ .Values.protectInit.path }}
+  port:
+    targetPort: {{ .Values.router.targetPort | default "http" }}
+  {{- if and .Values.protectInit.router.tls .Values.protectInit.router.tls.enabled }}
+  tls:
+    termination: {{ .Values.protectInit.router.tls.termination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ .Values.protectInit.router.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "webapp.fullname" . }}
+    weight: {{ .Values.router.weight | default 100 }}
+{{- end -}}

--- a/charts/otterdog/templates/router.yaml
+++ b/charts/otterdog/templates/router.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.router.enabled -}}
+{{- $fullName := include "webapp.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+  {{- with .Values.router.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.router.host }}
+  host: {{ .Values.router.host }}
+  {{- end }}
+  {{- if .Values.router.path }}
+  path: {{ .Values.router.path }}
+  {{- end }}
+  port:
+    targetPort: {{ .Values.router.targetPort | default "http" }}
+  {{- if and .Values.router.tls .Values.router.tls.enabled }}
+  tls:
+    termination: {{ .Values.router.tls.termination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ .Values.router.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    weight: {{ .Values.router.weight | default 100 }}
+{{- end -}}

--- a/charts/otterdog/templates/secrets.yaml
+++ b/charts/otterdog/templates/secrets.yaml
@@ -1,44 +1,90 @@
-# config.configToken
-{{- if .Values.config.configToken }}
+{{- if not .Values.vault.enabled }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: config-token-secret
+  name: {{ include "otterdog.secret.configToken" . }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
 type: Opaque
-data:
-  token: {{ .Values.config.configToken | quote }}
+stringData:
+  otterdog_config_token: {{ .Values.config.configToken | default "" | trim | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "otterdog.secret.webhookSecret" . }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  github_webhook_secret: {{ .Values.github.webhookSecret | default "" | trim | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "otterdog.secret.appPrivateKey" . }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  github_app_key: {{ .Values.github.appPrivateKey | default "" | trim | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "otterdog.secret.dependencyTrackToken" . }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  dependency_track_token: {{ .Values.config.dependencyTrackToken | default "" | trim | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "otterdog.secret.mongoUri" . }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  mongo_uri: {{ include "otterdog.mongodb.uri" . }}
+{{- if .Values.mongodb.auth.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-mongodb-root-credentials" (include "webapp.fullname" .) }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  mongodb_root_username: {{ .Values.mongodb.auth.rootUsername | default "root" | trim }}
+  mongodb_root_password: {{ .Values.mongodb.auth.rootPassword | default "" | trim }}
 {{- end }}
-# config.webhookSecret
-{{- if .Values.github.webhookSecret }}
 ---
+{{- $user := include "otterdog.mongodb.firstUser" . | fromJson }}
+{{- if get $user "name" }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-secret
+  name: {{ printf "%s-mongodb-app-credentials" (include "webapp.fullname" .) }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
 type: Opaque
-data:
-  secret: {{ .Values.github.webhookSecret | quote }}
+stringData:
+  CUSTOM_USER: {{ get $user "name" }}
+  CUSTOM_PASSWORD: {{ coalesce (get $user "password") .Values.config.mongoPassword "" | trim }}
+  CUSTOM_DB: {{ include "otterdog.mongodb.database" . }}
 {{- end }}
-# config.appPrivateKey
-{{- if .Values.github.appPrivateKey }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: app-private-key
+  name: {{ include "otterdog.secret.redisUri" . }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
 type: Opaque
-data:
-  app.key: {{ .Values.github.appPrivateKey | quote }}
-{{- end }}
-# config.dependencyTrackToken
-{{- if .Values.config.dependencyTrackToken }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dependency-track-token-secret
-type: Opaque
-data:
-  token: {{ .Values.config.dependencyTrackToken | quote }}
+stringData:
+  redis_uri: {{ include "otterdog.valkey.uri" . }}
 {{- end }}

--- a/charts/otterdog/templates/vault-static-secret.yaml
+++ b/charts/otterdog/templates/vault-static-secret.yaml
@@ -1,0 +1,324 @@
+{{- if .Values.vault.enabled }}
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: {{ include "webapp.fullname" . }}-vault-auth
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  method: kubernetes
+  {{- /*
+    authPath is "auth/kubernetes-..." — VSO expects the mount without the leading "auth/" prefix.
+  */}}
+  mount: {{ trimPrefix "auth/" .Values.vault.authPath }}
+  kubernetes:
+    role: {{ .Values.vault.role }}
+    serviceAccount: {{ .Values.vault.serviceAccountName | default "secrets-manager-sa"}}
+---
+{{- /*
+  VaultStaticSecret: otterdog_config_token → {{ include "otterdog.secret.configToken" . }}
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-config-token-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.configToken" . }}
+    create: true
+    transformation:
+      includes:
+        - otterdog_config_token
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+---
+{{- /*
+  VaultStaticSecret: github_webhook_secret → {{ include "otterdog.secret.webhookSecret" . }}
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-webhook-secret-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.webhookSecret" . }}
+    create: true
+    transformation:
+      includes:
+        - github_webhook_secret
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+---
+{{- /*
+  VaultStaticSecret: github_app_key → {{ include "otterdog.secret.appPrivateKey" . }}
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-app-private-key-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.appPrivateKey" . }}
+    create: true
+    transformation:
+      includes:
+        - github_app_key
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+---
+{{- /*
+  VaultStaticSecret: dependency_track_token → {{ include "otterdog.secret.dependencyTrackToken" . }}
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-dependency-track-token-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.dependencyTrackToken" . }}
+    create: true
+    transformation:
+      includes:
+        - dependency_track_token
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+---
+{{- /*
+  VaultStaticSecret: redis_uri → {{ include "otterdog.secret.redisUri" . }}
+  valkey.auth.enabled=false : URI statique depuis les valeurs Helm (pas de Vault key).
+  valkey.auth.enabled=true  : password depuis Vault key valkey_password.
+    username optionnel : config.redisUsername
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-valkey-uri-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.redisUri" . }}
+    create: true
+    transformation:
+      templates:
+        redis_uri:
+          text: {{ include "otterdog.valkey.vso.uri" . }}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- /*
+  mongo-uri VSS: three mutually exclusive variants.
+  - mongo-uri-app-vss    : customUsers is non-empty and customUsers[0].name is set → uses mongodb_app_password
+  - mongo-uri-root-vss   : no customUsers (or name missing) AND mongodb.auth.enabled   → uses mongodb_root_password
+  - mongo-uri-noauth-vss : no customUsers AND not mongodb.auth.enabled → no credentials
+*/}}
+{{- $firstUser := include "otterdog.mongodb.firstUser" . | fromJson }}
+{{- if get $firstUser "name" }}
+---
+{{- /*
+  VaultStaticSecret (app user): customUsers[0].name exists → mongo_uri uses mongodb_app_password.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-mongo-uri-app-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.mongoUri" . }}
+    create: true
+    transformation:
+      templates:
+        mongo_uri:
+          text: {{ include "otterdog.mongodb.vso.uri.app" . }}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- else if .Values.mongodb.auth.enabled }}
+---
+{{- /*
+  VaultStaticSecret (root user): no customUsers defined and auth.enabled → mongo_uri uses mongodb_root_password.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-mongo-uri-root-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.mongoUri" . }}
+    create: true
+    transformation:
+      templates:
+        mongo_uri:
+          text: {{ include "otterdog.mongodb.vso.uri.root" . }}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- else }}
+---
+{{- /*
+  VaultStaticSecret (no auth): no customUsers and mongodb.auth.enabled=false → mongo_uri has no credentials.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-mongo-uri-noauth-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "otterdog.secret.mongoUri" . }}
+    create: true
+    transformation:
+      templates:
+        mongo_uri:
+          text: {{ include "otterdog.mongodb.vso.uri.noauth" . }}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- end }}
+{{- if .Values.mongodb.enabled }}
+{{- if .Values.mongodb.auth.enabled }}
+---
+{{- /*
+  VaultStaticSecret: MongoDB root credentials.
+  mongodb_root_username : static from mongodb.auth.rootUsername (Helm value).
+  mongodb_root_password : synced from Vault key mongodb_root_password.
+  Destination K8s Secret: {{ include "webapp.fullname" . }}-mongodb-credentials
+  Used by the mongodb subchart via auth.existingSecret + existingSecretPasswordKey.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-mongodb-vault-secret
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "webapp.fullname" . }}-mongodb-root-credentials
+    create: true
+    transformation:
+      templates:
+        mongodb_root_password:
+          text: |-
+            {{`{{ .Secrets.mongodb_root_password }}`}}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- end }}
+{{- end }}
+{{- $firstUser := include "otterdog.mongodb.firstUser" . | fromJson }}
+{{- if get $firstUser "name" }}
+---
+{{- /*
+  VaultStaticSecret: MongoDB app user credentials (only when customUsers is defined).
+  Provides CUSTOM_USER / CUSTOM_PASSWORD / CUSTOM_DB for the cloudpirates/mongodb customUsers.
+  Username and database follow the same priority as otterdog.mongodb.username/database.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-mongodb-app-credentials-vss
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ tpl (include "otterdog.mongodb.firstUser" . | fromJson | dig "existingSecret" (printf "%s-mongodb-app-credentials" (include "webapp.fullname" .))) . }}
+    create: true
+    transformation:
+      templates:
+        CUSTOM_USER:
+          text: {{ include "otterdog.mongodb.username" . }}
+        CUSTOM_PASSWORD:
+          text: |-
+            {{`{{ .Secrets.mongodb_app_password }}`}}
+        CUSTOM_DB:
+          text: {{ include "otterdog.mongodb.database" . }}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- end }}
+
+{{- if .Values.valkey.enabled }}
+{{- if .Values.valkey.auth.enabled }}
+---
+{{- /*
+  VaultStaticSecret: ValKey root credentials.
+  valkey_password : synced from Vault key valkey_password.
+  Destination K8s Secret: {{ include "webapp.fullname" . }}-valkey-credentials
+  Used by the valkey subchart via auth.existingSecret + existingSecretPasswordKey.
+*/}}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "webapp.fullname" . }}-valkey-vault-secret
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: {{ .Values.vault.secretMount }}
+  path: {{ .Values.vault.secretPath }}
+  destination:
+    name: {{ include "webapp.fullname" . }}-valkey-credentials
+    create: true
+    transformation:
+      templates:
+        valkey_password:
+          text: |-
+            {{`{{ .Secrets.valkey_password }}`}}
+      excludes:
+        - ".*"
+  refreshAfter: {{ .Values.vault.operator.refreshAfter }}
+  vaultAuthRef: {{ include "webapp.fullname" . }}-vault-auth
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/otterdog/values.yaml
+++ b/charts/otterdog/values.yaml
@@ -7,135 +7,208 @@
 #  SPDX-License-Identifier: EPL-2.0
 #  *******************************************************************************
 #
-## @Section replicaCount
-## @param replicaCount Number of replicas to deploy
+# -- Number of replicas to deploy
 replicaCount: 1
 
-## @Section image
-## @param image.repository Image repository
-## @param image.tag image tag
-## @param image.pullPolicy image pull policy
 image:
+  # -- Image repository
   repository: ghcr.io/eclipse-csi/otterdog
+  # -- Image pull policy
   pullPolicy: IfNotPresent
-  tag: "1.3.4"
+  # -- Image tag (defaults to the chart appVersion if empty)
+  tag: ""
 
-## @param imagePullSecrets  image pull secrets
+# -- Image pull secrets
 imagePullSecrets: []
-## @param nameOverride name override for the chart
+# -- Name override for the chart
 nameOverride: ""
-## @param fullnameOverride full name override for the chart
+# -- Full name override for the chart
 fullnameOverride: ""
 
-## @Section config
-## @param config.debug Enable debug mode
-## @param config.baseUrl base URL for the application
-## @param config.cacheControl Enable cache control
-## @param config.appRoot application root directory
-## @param config.mongoUri MongoDB URI
-## @param config.redisUri Redis URI
-## @param config.ghProxyUri GitHub proxy URI
-## @param config.configOwner GitHub organization hosting the otterdog.json, e.g. MyOrg
-## @param config.configRepo GitHub repo hosting the otterdog.json, e.g. otterdog-configs
-## @param config.configPath Path to the otterdog.json, e.g. otterdog.json
-## @param config.configToken a valid GitHub token, no need for any permissions, just for rate limit purposes
-## @param config.dependencyTrackUrl Dependency-Track URL
-## @param config.dependencyTrackToken a valid Dependency-Track token, no need for any permissions, just for rate limit purposes
 config:
+  # -- Enable debug mode
   debug: false
+  # -- Base URL for the application
   baseUrl: "http://0.0.0.0:5000"
+  # -- Enable cache control
   cacheControl: false
+  # -- Application root directory
   appRoot: "/app/work"
-  mongoUri: "mongodb://root:changeme@otterdog-mongodb.default.svc.cluster.local:27017/otterdog"
-  redisUri: "redis://otterdog-valkey-primary.default.svc.cluster.local:6379"
-  ghProxyUri: "http://otterdog-ghproxy.default.svc.cluster.local:8888"
+  # -- MongoDB host (optional — auto-derived: `<release>-mongodb.<namespace>.svc.cluster.local`)
+  mongoHost: ""
+  # -- MongoDB port (optional — auto-derived: `27017`)
+  mongoPort: ""
+  # -- MongoDB database name
+  mongoDatabase: "otterdog"
+  # -- MongoDB username for the auto-derived URI (optional; defaults to customUsers[0].name)
+  mongoUsername: ""
+  # -- MongoDB password for the auto-derived URI (optional; defaults to customUsers[0].password)
+  mongoPassword: ""
+  # -- Redis URI (optional — auto-derived: `redis://<release>-valkey.<namespace>.svc.cluster.local:6379`)
+  valkeyUri: ""
+  # -- Redis/Valkey username for the auto-derived URI (optional; ignored when valkeyUri is set)
+  valkeyUsername: ""
+  # -- Redis/Valkey password for the auto-derived URI (optional; ignored when valkeyUri is set)
+  valkeyPassword: ""
+  # -- GitHub proxy URI (optional — auto-derived: `http://<release>-ghproxy.<namespace>.svc.cluster.local:8888`)
+  ghProxyUri: ""
+  # -- GitHub organization hosting the otterdog.json, e.g. MyOrg (https://github.com/MyOrg)
   configOwner: ""
+  # -- GitHub repo hosting the otterdog.json, e.g. (https://github.com/MyOrg/.otterdog)
   configRepo: ".otterdog"
+  # -- Path to the otterdog.json, e.g. otterdog.json
   configPath: "/app/otterdog.json"
+  # -- A valid GitHub token, no need for any permissions, just for rate limit purposes
   configToken: ""
+  # -- Dependency-Track URL
   dependencyTrackUrl: ""
+  # -- A valid Dependency-Track token, no need for any permissions, just for rate limit purposes
   dependencyTrackToken: ""
 
-## @Section policies
-## @param policies.enabled Enable the policy check CronJob
-## @param policies.schedule Cron schedule for the policy check
-## @param policies.batchSize Number of checks per invocation
-policies:
+initJob:
+  # -- Run a Helm post-install/post-upgrade hook Job that calls /internal/init
+  # (refreshes org configs, policies and blueprints) after every install/upgrade.
   enabled: true
+  # -- Number of retries before the Job is considered failed
+  backoffLimit: 4
+
+policies:
+  # -- Enable the policy check CronJob
+  enabled: true
+  # -- Cron schedule for the policy check
   schedule: "*/5 * * * *"
+  # -- Number of checks per invocation
   batchSize: 10
 
-## @Section GitHub
-## @param github.adminTeams GitHub admin teams
-## @param github.webhookEndpoint GitHub webhook endpoint
-## @param github.webhookSecret GitHub webhook secret
-## @param github.webhookValidationContext GitHub webhook validation context
-## @param github.webhookSyncContext GitHub webhook sync context
-## @param github.appId GitHub app ID
-## @param github.appPrivateKey GitHub app private key
 github:
+  # -- GitHub admin teams
   adminTeams: "otterdog-admins"
+  # -- GitHub webhook endpoint
   webhookEndpoint: /github-webhook/receive""
+  # -- GitHub webhook secret
   webhookSecret: ""
+  # -- GitHub webhook validation context
   webhookValidationContext: ""
+  # -- GitHub webhook sync context
   webhookSyncContext: ""
+  # -- GitHub app ID
   appId: ""
+  # -- GitHub app private key
   appPrivateKey: ""
 
-## @Section Ingress
-## @param ingress.enabled Enable ingress
-## @param ingress.className Ingress class name
-## @params ingress.defaultBackend Default backend for the ingress
-## @param ingress.defaultBackend.enabled Enable default backend
-## @param ingress.annotations Ingress annotations
-## @param ingress.hosts Ingress hosts
+# When vault.enabled is true, secrets are synced from Vault via the Vault Secrets Operator (VSO)
+# into dedicated K8s Secrets (one per secret). Vault key mapping:
+#   otterdog_config_token   → <release>-config-token            (key: otterdog_config_token)
+#   github_webhook_secret   → <release>-webhook-secret          (key: github_webhook_secret)
+#   github_app_key          → <release>-app-private-key         (key: github_app_key)
+#   dependency_track_token  → <release>-dependency-track-token  (key: dependency_track_token)
+#   mongodb_app_password    → <release>-mongo-uri               (key: mongo_uri, app-user URI built by VSO template)
+#   mongodb_app_password    → <release>-mongodb-app-credentials        (keys: CUSTOM_USER/CUSTOM_PASSWORD/CUSTOM_DB)
+#   mongodb_root_password   → <release>-mongodb-credentials     (key: mongodb_root_password, used to create the app user)
+vault:
+  # -- Enable Vault Secrets Operator (VSO) integration for secrets
+  enabled: false
+  # -- Skip TLS verification when connecting to Vault
+  tlsSkipVerify: true
+  # -- Vault Kubernetes auth path, e.g. auth/kubernetes-<instance>-<env>-<namespace>
+  authPath: ""
+  # -- Vault role for authentication, e.g. <instance>-<env>_<namespace>_role
+  role: ""
+  # -- Vault KV v2 secrets engine mount path, e.g. csi
+  secretMount: "csi"
+  # -- Full path inside the mount, e.g. otterdog/<env> → csi/data/otterdog/staging
+  secretPath: "otterdog/dev"
+  # -- Service account name for the Vault Kubernetes auth method (optional; defaults to "secrets-manager-sa")
+  serviceAccountName: "secrets-manager-sa"
+  # -- VSO operator configuration
+  operator:
+    # -- How often VSO syncs the secret from Vault (e.g. 30s, 1m)
+    refreshAfter: "30s"
+
 ingress:
+  # -- Enable ingress
   enabled: true
   defaultBackend:
+    # -- Enable default backend
     enabled: false
+  # -- Ingress class name
   className: "nginx"
+  # -- Ingress annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # -- Ingress hosts
   hosts:
     - host: otterdog.local
       paths:
         - path: /
           pathType: ImplementationSpecific
 
-## @Section Router
-## @param router.enabled Enable router
-## @param router.className Router class name
-## @param router.annotations Router annotations
-## @param router.hosts Router hosts
 router:
+  # -- Enable router (OpenShift Route)
   enabled: false
+  tls:
+    # -- Enable TLS termination on the route
+    enabled: true
+    # -- TLS termination type (edge, passthrough, reencrypt)
+    termination: edge
+    # -- Behavior for insecure (HTTP) traffic on a TLS route
+    insecureEdgeTerminationPolicy: Redirect
 
-## @section Service
-## @param service.type Service type
-## @param service.port Service port
+# Dedicated Ingress + OpenShift Route restricted to a single internal path (e.g. health/admin
+# endpoints), named "otterdog-protect-init-<env>" so it can carry its own access-restriction
+# annotations (IP allowlist, auth, ...) independently of the main ingress/router.
+protectInit:
+  # -- Path restricted to this dedicated Ingress/Route
+  path: /internal/
+  ingress:
+    # -- Enable a dedicated Ingress restricted to protectInit.path
+    enabled: false
+    # -- Ingress class name
+    className: "nginx"
+    # -- Ingress annotations (e.g. IP allowlist, auth)
+    annotations: {}
+    # -- Host for the dedicated Ingress
+    host: otterdog.local
+  router:
+    # -- Enable a dedicated OpenShift Route restricted to protectInit.path
+    enabled: false
+    # -- Host for the dedicated Route (defaults to router.host when empty)
+    host: ""
+    # -- Route annotations (e.g. IP allowlist, auth)
+    annotations: {}
+    tls:
+      # -- Enable TLS termination on the route
+      enabled: true
+      # -- TLS termination type (edge, passthrough, reencrypt)
+      termination: edge
+      # -- Behavior for insecure (HTTP) traffic on a TLS route
+      insecureEdgeTerminationPolicy: Redirect
+
 service:
+  # -- Service type
   type: NodePort
+  # -- Service port
   port: 5000
 
-## @section ServiceAccount
-## @param serviceAccount.create Create a service account
-## @param serviceAccount.automount Automount the service account
-## @param serviceAccount.annotations Service account annotations
-## @param serviceAccount.name Service account name
 serviceAccount:
+  # -- Create a service account
   create: true
+  # -- Automount the service account token
   automount: true
+  # -- Service account annotations
   annotations: {}
+  # -- Service account name
   name: ""
 
-## @param podAnnotations pod annotations
-## @param podLabels pod labels
-## @param podSecurityContext pod security context
+# -- Pod annotations
 podAnnotations: {}
+# -- Pod labels
 podLabels: {}
+# -- Pod security context
 podSecurityContext: {}
   # fsGroup: 2000
+# -- Container security context
 securityContext: {}
   # capabilities:
   #   drop:
@@ -144,6 +217,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- Resource requests and limits for the otterdog container
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -156,68 +230,147 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Override the default init containers (wait-for-mongodb, wait-for-redis)
+initContainers: []
+
 autoscaling:
+  # -- Enable Horizontal Pod Autoscaler
   enabled: false
+  # -- Minimum number of replicas
   minReplicas: 1
+  # -- Maximum number of replicas
   maxReplicas: 100
+  # -- Target CPU utilization percentage
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# Additional volumes on the output Deployment definition.
+# -- Additional volumes on the output Deployment definition
 volumes: []
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+# -- Additional volumeMounts on the output Deployment definition
 volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# -- Node labels for pod assignment
 nodeSelector: {}
 
+# -- Tolerations for pod assignment
 tolerations: []
 
+# -- Affinity rules for pod assignment
 affinity: {}
 
-# @section livenessProbe
-# @param livenessProbe.httpGet.path Liveness probe path
-# @param livenessProbe.httpGet.port Liveness probe port
+# -- Startup probe: gates liveness/readiness until the app is listening, so slow
+# starts don't trigger "connection refused" failures or premature restarts.
+startupProbe:
+  httpGet:
+    # -- Startup probe path
+    path: /internal/health
+    # -- Startup probe port
+    port: http
+  # -- Delay before the first startup check
+  initialDelaySeconds: 5
+  # -- How often to probe during startup
+  periodSeconds: 5
+  # -- Probe timeout
+  timeoutSeconds: 3
+  # -- Failures allowed before the container is restarted (5s * 24 = up to 120s to start)
+  failureThreshold: 24
 livenessProbe:
   httpGet:
+    # -- Liveness probe path
     path: /internal/health
+    # -- Liveness probe port
     port: http
-# @section readinessProbe
-# @param readinessProbe.httpGet.path Readiness probe path
-# @param readinessProbe.httpGet.port Readiness probe port
+  # -- How often to probe
+  periodSeconds: 15
+  # -- Probe timeout
+  timeoutSeconds: 3
+  # -- Consecutive failures before the container is restarted
+  failureThreshold: 3
 readinessProbe:
   httpGet:
+    # -- Readiness probe path
     path: /internal/health
+    # -- Readiness probe port
     port: http
+  # -- Delay before the first readiness check
+  initialDelaySeconds: 5
+  # -- How often to probe
+  periodSeconds: 10
+  # -- Probe timeout
+  timeoutSeconds: 3
+  # -- Consecutive failures before the pod is marked unready
+  failureThreshold: 3
+  # -- Consecutive successes before the pod is marked ready
+  successThreshold: 1
 
-# @mongodb section
-# @param mongodb.enabled Enable MongoDB
-# @param mongodb.auth.enabled Enable MongoDB authentication
-# @param mongodb.auth.rootPassword MongoDB root password
 mongodb:
+  # -- Enable MongoDB subchart (cloudpirates/mongodb OCI chart)
   enabled: true
   auth:
+    # -- Enable MongoDB authentication
     enabled: true
+    # -- MongoDB root username
+    rootUsername: root
+    # -- MongoDB root password (set to "" when vault.enabled; the subchart uses this to bootstrap the app user)
     rootPassword: changeme
+    existingSecret: '{{ printf "%s-mongodb-root-credentials" .Release.Name }}'
+    existingSecretPasswordKey: "mongodb_root_password"
+  # -- Name of the K8s Secret holding the app user credentials for vault mode.
+  # Created by vault-static-secret.yaml when vault.enabled.
+  # Must match customUsers[0].existingSecret — set both to the same value.
+  # Non-vault mode: leave password set and existingSecret commented out.
+  # Vault mode: comment out password and uncomment existingSecret/secretKeys.
+  customUsers:
+    - name: otterdog
+      database: otterdog
+      # password is kept for Helm-side URI construction (mongo_uri secret, secrets.yaml).
+      # The subchart reads credentials from existingSecret — password is ignored by the subchart.
+      password: changeme
+      existingSecret: '{{ printf "%s-mongodb-app-credentials" .Release.Name }}'
+      secretKeys:
+        name: CUSTOM_USER
+        password: CUSTOM_PASSWORD
+        database: CUSTOM_DB
+      roles:
+        - readWrite
+  # -- MongoDB persistence (PersistentVolumeClaim) configuration, passed to the mongodb subchart
+  persistence:
+    # -- Enable a PersistentVolumeClaim for MongoDB data
+    enabled: true
+    # -- StorageClass for the PVC (empty = cluster default)
+    storageClass: ""
+    # -- Access mode for the PVC
+    accessMode: ReadWriteOnce
+    # -- Size of the PVC
+    size: 8Gi
 
-# @valkey section
-# @param valkey.enabled Enable Valkey
-# @param valkey.auth.enabled Enable Valkey authentication
 valkey:
+  # -- Enable Valkey subchart (cloudpirates/valkey OCI chart)
   enabled: true
   auth:
-    enabled: false
+    # -- Enable Valkey authentication
+    enabled: true
+    password: "changeme"
+    # existingSecret: '{{ printf "%s-valkey-credentials" .Release.Name }}'
+    # existingSecretPasswordKey: "valkey_password"
+  ## @section Persistence
+  persistence:
+    ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+    enabled: true
+    ## @param persistence.size Persistent Volume size
+    size: 8Gi
+    ## @param persistence.accessModes Persistent Volume access modes
+    accessModes:
+      - ReadWriteOnce
 
-# @ghproxy section
-# @param ghproxy.enabled Enable ghproxy
-# @param ghproxy.redisAddress ghproxy Redis address
 ghproxy:
+  # -- Enable ghproxy
   enabled: true
-  redisAddress: otterdog-valkey-primary.default.svc.cluster.local:6379


### PR DESCRIPTION
## Vault integration

### Vault mode (`vault.enabled: true`)

Secrets are synced from HashiCorp Vault by the
[Vault Secrets Operator (VSO)](https://developer.hashicorp.com/vault/docs/platform/k8s/vso).
`templates/vault-static-secret.yaml` creates one `VaultStaticSecret` per secret, each syncing
into its own Kubernetes `Secret`.

All keys are read from a single Vault KV v2 entry:

```
<vault.secretMount>/data/<vault.secretPath>     e.g. csi/data/otterdog/dev
```

The following keys must exist in that Vault entry:

| Vault key | Kubernetes Secret (VSO destination) | Consumed as |
| --------- | ----------------------------------- | ----------- |
| `otterdog_config_token` | `<release>-config-token` | env `OTTERDOG_CONFIG_TOKEN` |
| `github_webhook_secret` | `<release>-webhook-secret` | env `GITHUB_WEBHOOK_SECRET` |
| `github_app_key` | `<release>-app-private-key` | file `/run/secrets/app-private-key/app.key` (env `GITHUB_APP_PRIVATE_KEY`) |
| `dependency_track_token` | `<release>-dependency-track-token` | env `DEPENDENCY_TRACK_TOKEN` |
| `mongodb_root_password` | `<release>-mongodb-root-credentials` | MongoDB subchart root password; also embedded in `MONGO_URI` when no `mongodb.customUsers` are configured |
| `mongodb_app_password` | `<release>-mongodb-app-credentials` (key `CUSTOM_PASSWORD`) and `<release>-mongo-uri` (env `MONGO_URI`) | MongoDB app user password |
| `valkey_password` | `<release>-valkey-credentials` | Valkey subchart password (used by the `valkey` sub-chart itself via `auth.existingSecret`/`auth.existingSecretPasswordKey`); only synced when `valkey.enabled` and `valkey.auth.enabled` |
| `valkey_password` | `<release>-valkey-uri` (env `REDIS_URI`) | Same password, embedded in the app's `REDIS_URI` when `valkey.auth.enabled`; when `valkey.auth.enabled: false`, `REDIS_URI` is still created but with no credentials |

Notes:

- `MONGO_URI` is built by one of three mutually exclusive `VaultStaticSecret` variants,
  selected automatically based on `mongodb.customUsers` / `mongodb.auth.enabled`:
  - `mongodb.customUsers` configured → uses `mongodb_app_password`, with
    `authSource=<mongodb.customUsers[0].database>` (default `otterdog`).
  - no `customUsers`, `mongodb.auth.enabled: true` → uses `mongodb_root_password`, with
    `authSource=admin` — MongoDB's root user always lives in the `admin` database,
    regardless of `config.mongoDatabase`.
  - `mongodb.auth.enabled: false` → no credentials at all in `MONGO_URI`.
- `mongodb_root_password` is also used by the MongoDB subchart to bootstrap the root user
  (and the app user, when `mongodb.customUsers` is configured).
- Similarly, `valkey_password` has two destinations: `<release>-valkey-credentials` bootstraps
  the Valkey server itself (subchart-consumed), while `<release>-valkey-uri` is what the
  otterdog app actually connects with (`REDIS_URI`) — keep both in sync if you rotate it
  manually instead of just updating the Vault value.
- Vault connection settings (auth path, role, mount and path) are configured under the
  `vault.*` values below.