### PR TITLE
pia: bump to 0.6.0

### DIFF
--- a/charts/pia/Chart.yaml
+++ b/charts/pia/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pia
 description: A Helm chart for PIA (Project Identity Authority)
 type: application
-version: 0.2.0
-appVersion: "0.5.0"
+version: 0.2.1
+appVersion: "0.6.0"
 keywords:
   - pia
   - dependency-track

--- a/charts/pia/values.yaml
+++ b/charts/pia/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/eclipse-csi/pia
   pullPolicy: IfNotPresent
-  tag: "0.5.0"
+  tag: "0.6.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Update appVersion and image tag to PIA 0.6.0, and bump the chart version accordingly. No template changes are required: 0.6.0 introduces no new or renamed settings, and its new Alembic revision is applied by the existing pre-install/pre-upgrade migration job.

Assisted-by: Claude:claude-opus-5