### PR TITLE
fix empty values for GITHUB_WEBHOOK_*

### DIFF
--- a/charts/otterdog/Chart.yaml
+++ b/charts/otterdog/Chart.yaml
@@ -26,7 +26,7 @@ maintainers:
     url: https://github.com/eclipse-csi/otterdog/
 type: application
 kubeVersion: ">=1.23.0-0"
-version: 1.2.1
+version: 1.2.2
 appVersion: "1.4.0"
 dependencies:
   - name: ghproxy

--- a/charts/otterdog/README.md
+++ b/charts/otterdog/README.md
@@ -1,6 +1,6 @@
 # otterdog
 
-![Version: 1.2.1][version-badge] <!-- x-release-please-version -->
+![Version: 1.2.2][version-badge] <!-- x-release-please-version -->
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
@@ -329,5 +329,5 @@ Notes:
 | ghproxy.enabled | bool | `true` | Enable ghproxy |
 
 <!-- x-release-please-start-version -->
-[version-badge]: https://img.shields.io/badge/Version-1.2.1%2Dinformational?style=flat-square
+[version-badge]: https://img.shields.io/badge/Version-1.2.2%2Dinformational?style=flat-square
 <!-- x-release-please-end -->

--- a/charts/otterdog/README.md
+++ b/charts/otterdog/README.md
@@ -235,8 +235,8 @@ Notes:
 | github.adminTeams | string | `"otterdog-admins"` | GitHub admin teams |
 | github.webhookEndpoint | string | `"/github-webhook/receive\"\""` | GitHub webhook endpoint |
 | github.webhookSecret | string | `""` | GitHub webhook secret |
-| github.webhookValidationContext | string | `""` | GitHub webhook validation context |
-| github.webhookSyncContext | string | `""` | GitHub webhook sync context |
+| github.webhookValidationContext | string | `"otterdog/otterdog-validate"` | GitHub webhook validation context |
+| github.webhookSyncContext | string | `"otterdog/otterdog-sync"` | GitHub webhook sync context |
 | github.appId | string | `""` | GitHub app ID |
 | github.appPrivateKey | string | `""` | GitHub app private key |
 | vault.enabled | bool | `false` | Enable Vault Secrets Operator (VSO) integration for secrets |

--- a/charts/otterdog/values.yaml
+++ b/charts/otterdog/values.yaml
@@ -88,9 +88,9 @@ github:
   # -- GitHub webhook secret
   webhookSecret: ""
   # -- GitHub webhook validation context
-  webhookValidationContext: ""
+  webhookValidationContext: "otterdog/otterdog-validate"
   # -- GitHub webhook sync context
-  webhookSyncContext: ""
+  webhookSyncContext: "otterdog/otterdog-sync"
   # -- GitHub app ID
   appId: ""
   # -- GitHub app private key


### PR DESCRIPTION
Fix empty values for GITHUB_WEBHOOK_VALIDATION_CONTEXT and GITHUB_WEBHOOK_SYNC_CONTEXT

Avoid this kind of error:

```shell

[2026-07-28 10:00:00.012  ] [8] [ERROR] failed to execute task 'CheckConfigurationInSyncTask(repo='eclipse-kura/.eclipsefdn', pull_request=#71)'                           │
│ otterdog Traceback (most recent call last):                                                                                                                                         │
│ otterdog   File "/app/otterdog/webapp/tasks/__init__.py", line 68, in execute                                                                                                       │
│ otterdog     if await self._pre_execute() is True:                                                                                                                                  │
│ otterdog        ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                           │
│ otterdog   File "/app/otterdog/webapp/tasks/check_sync.py", line 132, in _pre_execute                                                                                               │
│ otterdog     await self._create_pending_status()                                                                                                                                    │
│ otterdog   File "/app/otterdog/webapp/tasks/check_sync.py", line 217, in _create_pending_status                                                                                     │
│ otterdog     await rest_api.commit.create_commit_status(                                                                                                                            │
│ otterdog   File "/app/otterdog/providers/github/rest/commit_client.py", line 58, in create_commit_status                                                                            │
│ otterdog     raise RuntimeError(f"failed creating commit status for '{org_id}/{repo_name}/{sha}'\n{status}: {body}")                                                                │
│ otterdog RuntimeError: failed creating commit status for 'eclipse-kura/.eclipsefdn/b9c3ee28a8d0aa7d04b1883280fdbc26844980ab'                                                        │
│ otterdog 422: {"message":"Validation Failed","errors":"Validation failed: Context can't be blank","documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commi │
│ otterdog [2026-07-28 10:00:00.175  ] [8] [ERROR] Exception on request POST /github-webhook/receive                                                                                  │
│ otterdog Traceback (most recent call last):                                                                                                                                         │
│ otterdog   File "/app/otterdog/webapp/tasks/__init__.py", line 68, in execute                                                                                                       │
│ otterdog     if await self._pre_execute() is True:                                                                                                                                  │
│ otterdog        ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                           │
│ otterdog   File "/app/otterdog/webapp/tasks/check_sync.py", line 132, in _pre_execute                                                                                               │
│ otterdog     await self._create_pending_status()                                                                                                                                    │
│ otterdog   File "/app/otterdog/webapp/tasks/check_sync.py", line 217, in _create_pending_status                                                                                     │
│ otterdog     await rest_api.commit.create_commit_status(                                                                                                                            │
│ otterdog   File "/app/otterdog/providers/github/rest/commit_client.py", line 58, in create_commit_status                                                                            │
│ otterdog     raise RuntimeError(f"failed creating commit status for '{org_id}/{repo_name}/{sha}'\n{status}: {body}")                                                                │
│ otterdog RuntimeError: failed creating commit status for 'eclipse-kura/.eclipsefdn/b9c3ee28a8d0aa7d04b1883280fdbc26844980ab'                                                        │
│ otterdog 422: {"message":"Validation Failed","errors":"Validation failed: Context can't be blank","documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commi │
│ otterdog                                                                                                                                                                            │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/quart/app.py", line 1374, in _wrapper                                                                                      │
│ otterdog     await self.ensure_async(func)(*args, **kwargs)                                                                                                                         │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/quart_flask_patch/app.py", line 44, in _wrapper                                                                            │
│ otterdog     return await result                                                                                                                                                    │
  File "/app/otterdog/webapp/tasks/__init__.py", line 56, in __call__                                                                                                      │
│ otterdog     await self.execute()                                                                                                                                                   │
│ otterdog   File "/app/otterdog/webapp/tasks/__init__.py", line 77, in execute                                                                                                       │
│ otterdog     await self._post_execute(ex)                                                                                                                                           │
│ otterdog   File "/app/otterdog/webapp/tasks/check_sync.py", line 138, in _post_execute                                                                                              │
│ otterdog     await self._create_failure_status()                                                                                                                                    │
│ otterdog   File "/app/otterdog/webapp/tasks/check_sync.py", line 228, in _create_failure_status                                                                                     │
│ otterdog     await rest_api.commit.create_commit_status(                                                                                                                            │
│ otterdog   File "/app/otterdog/providers/github/rest/commit_client.py", line 58, in create_commit_status                                                                            │
│ otterdog     raise RuntimeError(f"failed creating commit status for '{org_id}/{repo_name}/{sha}'\n{status}: {body}")                                                                │
│ otterdog RuntimeError: failed creating commit status for 'eclipse-kura/.eclipsefdn/b9c3ee28a8d0aa7d04b1883280fdbc26844980ab'                                                        │
│ otterdog 422: {"message":"Validation Failed","errors":"Validation failed: Context can't be blank","documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commi │
│ otterdog             
``