### PR TITLE
pia: define the project authorization sync job in the chart

### DIFF
--- a/charts/pia/Chart.yaml
+++ b/charts/pia/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pia
 description: A Helm chart for PIA (Project Identity Authority)
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "0.6.0"
 keywords:
   - pia

--- a/charts/pia/templates/_helpers.tpl
+++ b/charts/pia/templates/_helpers.tpl
@@ -51,6 +51,46 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Image the one-off sync job runs. Defaults to the app image, so the sync CLI
+matches the deployed app and its database schema.
+*/}}
+{{- define "pia.sync.image" -}}
+{{- if .Values.sync.image -}}
+{{- .Values.sync.image -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+DependencyTrack base URL for the sync job. The app is configured with the
+/api/v1/bom upload endpoint; the CLI wants the base URL.
+*/}}
+{{- define "pia.sync.dtUrl" -}}
+{{- if .Values.sync.dtUrl -}}
+{{- .Values.sync.dtUrl -}}
+{{- else -}}
+{{- .Values.config.dependencyTrackUrl | trimSuffix "/" | trimSuffix "/api/v1/bom" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Names of the existing secrets the sync job reads its credentials from. Each
+defaults to a suffix of the release fullname.
+*/}}
+{{- define "pia.sync.dbSecretName" -}}
+{{- .Values.sync.dbExistingSecret | default (printf "%s-db-cli" (include "pia.fullname" .)) -}}
+{{- end }}
+
+{{- define "pia.sync.dtApiSecretName" -}}
+{{- .Values.sync.dtApiExistingSecret | default (printf "%s-dt-cli" (include "pia.fullname" .)) -}}
+{{- end }}
+
+{{- define "pia.sync.githubSecretName" -}}
+{{- .Values.sync.githubExistingSecret | default (printf "%s-gh" (include "pia.fullname" .)) -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "pia.serviceAccountName" -}}

--- a/charts/pia/templates/sync-configmap.yaml
+++ b/charts/pia/templates/sync-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.sync.enabled }}
+{{- $msg := "sync.enabled requires sync.projects to hold the contents of projects.yaml (pass it with --set-file sync.projects=<path>)" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pia.fullname" . }}-projects
+  labels:
+    {{- include "pia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sync
+data:
+  projects.yaml: |
+    {{- required $msg .Values.sync.projects | trimSuffix "\n" | nindent 4 }}
+{{- end }}

--- a/charts/pia/templates/sync-job.yaml
+++ b/charts/pia/templates/sync-job.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.sync.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Fixed name: a sync is a one-off operation and only one run makes sense at a
+  # time. A Job spec is immutable, so the previous run has to be deleted before
+  # this one is applied.
+  name: {{ include "pia.fullname" . }}-sync
+  labels:
+    {{- include "pia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sync
+spec:
+  backoffLimit: {{ .Values.sync.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.sync.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "pia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: sync
+      {{- with .Values.sync.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pia.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: sync
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "pia.sync.image" . | quote }}
+          imagePullPolicy: {{ .Values.sync.imagePullPolicy | default .Values.image.pullPolicy }}
+          # Override the image's default command (uvicorn) to run the sync CLI.
+          # The CLI, the app and the alembic migrations ship as one image and are
+          # version-locked to the database schema.
+          command:
+            - python
+            - -m
+            - pia.cli
+            - --verbose
+            - sync
+            - /config/projects.yaml
+            # Sync resolves project names against DependencyTrack, and must use
+            # the same instance the app uploads to.
+            - --dt-url
+            - {{ include "pia.sync.dtUrl" . | quote }}
+            {{- range .Values.sync.args }}
+            - {{ . | quote }}
+            {{- end }}
+          envFrom:
+            # The sync user writes to the database and only reads from
+            # DependencyTrack, so it gets its own credentials, separate from
+            # those of the app and of the migration job.
+            - secretRef:
+                name: {{ include "pia.sync.dbSecretName" . }}
+            - secretRef:
+                name: {{ include "pia.sync.dtApiSecretName" . }}
+            - secretRef:
+                name: {{ include "pia.sync.githubSecretName" . }}
+          volumeMounts:
+            - name: projects
+              mountPath: /config
+              readOnly: true
+          resources:
+            {{- toYaml .Values.sync.resources | nindent 12 }}
+      volumes:
+        - name: projects
+          configMap:
+            name: {{ include "pia.fullname" . }}-projects
+{{- end }}

--- a/charts/pia/values.yaml
+++ b/charts/pia/values.yaml
@@ -72,6 +72,71 @@ migration:
   podAnnotations: {}
   resources: {}
 
+## One-off project authorization sync job
+# Runs "pia sync <projects.yaml>", which reconciles the project authorizations in
+# the database to a curated projects.yaml. Sync needs database access, which
+# typically only exists inside the cluster, so it runs as a Job from the app
+# image, with projects.yaml mounted from a ConfigMap this chart also renders.
+#
+# Unlike the migration above, a sync is NOT part of a release: it is a manual,
+# reviewed operation (a full reconcile that can delete rows), so both the Job and
+# the ConfigMap are off by default. Render them on demand instead, without
+# touching the release:
+#
+#   helm template <release> eclipse-csi/pia --version <chart-version> \
+#     --values <the release's values.yaml> \
+#     --set sync.enabled=true \
+#     --set-file sync.projects=projects.yaml \
+#     --set-json 'sync.args=["--dry-run"]' \
+#     --show-only templates/sync-configmap.yaml \
+#     --show-only templates/sync-job.yaml | kubectl apply -f -
+#
+# The pia.eclipse.org repository wraps exactly that in its sync.sh.
+sync:
+  enabled: false
+
+  # Contents of projects.yaml, mounted at /config/projects.yaml. Required when
+  # sync.enabled is true; pass the curated file with
+  # --set-file sync.projects=<path> rather than inlining it here.
+  projects: ""
+
+  # Extra arguments for "pia sync", e.g. ["--dry-run"] to only print the plan, or
+  # ["--allow-db-updates-and-deletions"] to let it apply a plan that is not
+  # purely additive. --dt-url is set from dtUrl below and must not be repeated.
+  args: []
+
+  # DependencyTrack base URL sync resolves project names against. Defaults to
+  # config.dependencyTrackUrl minus its /api/v1/bom upload path, so sync uses the
+  # same instance the app uploads to.
+  dtUrl: ""
+
+  # Image and pull policy for the sync job. Both default to the app image, which
+  # ships the sync CLI and is version-locked to the database schema. Override
+  # only to run a different build of the CLI.
+  image: ""
+  imagePullPolicy: ""
+
+  # Existing secrets holding the sync credentials, provisioned out of band. Sync
+  # writes to the database and reads from DependencyTrack and GitHub, so it needs
+  # its own credentials, separate from the app's and the migration user's:
+  #   dbExistingSecret        PIA_DATABASE_URL, user needs INSERT/UPDATE/DELETE
+  #   dtApiExistingSecret     PIA_DEPENDENCY_TRACK_API_KEY, needs VIEW_PORTFOLIO
+  #   githubExistingSecret    PIA_GITHUB_TOKEN, needs no permissions/scopes; it
+  #                           only lifts the anonymous rate limit
+  # Every key in each secret is exposed to the job as an environment variable.
+  # Defaults: <fullname>-db-cli, <fullname>-dt-cli and <fullname>-gh.
+  dbExistingSecret: ""
+  dtApiExistingSecret: ""
+  githubExistingSecret: ""
+
+  # Job tuning. backoffLimit caps retries; activeDeadlineSeconds bounds a sync
+  # that hangs on an unreachable database or DependencyTrack.
+  backoffLimit: 1
+  activeDeadlineSeconds: 600
+
+  podAnnotations: {}
+  resources: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
`pia sync` reconciles the project authorizations in the database to a curated projects.yaml. It needs database access, which typically only exists inside the cluster, so it runs as a one-off Job from the app image, with projects.yaml mounted from a ConfigMap.

Both manifests were assembled on the fly by pia.eclipse.org/sync.sh, even though everything in them — image, DependencyTrack URL, secret names, labels, security context — belongs to a Helm release. Define them here instead, configured through new `sync.*` values, and let the deployment repository render them.

A sync is deliberately not part of a release: it is a manual, reviewed operation, and a full reconcile that can delete rows. So `sync.enabled` is off by default and the templates render nothing for an ordinary install or upgrade. They are meant to be rendered on demand with `helm template --show-only`, which the values.yaml comment spells out.

Two details the ad-hoc manifests had to hardcode now follow the release: --dt-url defaults to `config.dependencyTrackUrl` minus its /api/v1/bom upload path, so sync resolves project names against the same DependencyTrack the app uploads to, and the pod and container security contexts come from the chart values, so a namespace that injects its own UID/GID is honoured here as it is for the app and migration pods.

Assisted-by: Claude:claude-opus-5