### PR TITLE
pia: cleanup chart and job, and bump to 0.3.1

### DIFF
--- a/charts/pia/Chart.yaml
+++ b/charts/pia/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pia
 description: A Helm chart for PIA (Project Identity Authority)
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.6.0"
 keywords:
   - pia

--- a/charts/pia/templates/sync-job.yaml
+++ b/charts/pia/templates/sync-job.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   backoffLimit: {{ .Values.sync.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.sync.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.sync.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/charts/pia/values.yaml
+++ b/charts/pia/values.yaml
@@ -132,8 +132,10 @@ sync:
 
   # Job tuning. backoffLimit caps retries; activeDeadlineSeconds bounds a sync
   # that hangs on an unreachable database or DependencyTrack.
+  # ttlSecondsAfterFinished auto-deletes after a set time. Default: 1 day.
   backoffLimit: 1
   activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 86400
 
   podAnnotations: {}
   resources: {}

--- a/charts/pia/values.yaml
+++ b/charts/pia/values.yaml
@@ -5,7 +5,8 @@ replicaCount: 1
 image:
   repository: ghcr.io/eclipse-csi/pia
   pullPolicy: IfNotPresent
-  tag: "0.6.0"
+  # Empty tag defaults to .Chart.appVersion
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
* deduplicate `appVersion`/`tag` in pia chart
* auto-delete a finished job with `ttlSecondsAfterFinished`
